### PR TITLE
Fix the type of `BinXOptions` and `BinYOptions`

### DIFF
--- a/src/lib/transforms/bin.ts
+++ b/src/lib/transforms/bin.ts
@@ -39,17 +39,17 @@ type AdditionalOutputChannels = Partial<{
 export type BinXOptions = BinBaseOptions &
     AdditionalOutputChannels &
     Partial<{
-        y: typeof Reducer;
-        y1: typeof Reducer;
-        y2: typeof Reducer;
+        y: ReducerOption;
+        y1: ReducerOption;
+        y2: ReducerOption;
     }>;
 
 export type BinYOptions = BinBaseOptions &
     AdditionalOutputChannels &
     Partial<{
-        x: typeof Reducer;
-        x1: typeof Reducer;
-        x2: typeof Reducer;
+        x: ReducerOption;
+        x1: ReducerOption;
+        x2: ReducerOption;
     }>;
 
 type BinOptions = BinBaseOptions & AdditionalOutputChannels;


### PR DESCRIPTION
I see this type error with the first example of getting started. I think `ReducerOption` is the intended type.

```ts
            { y: 'count' }
```
```
Type 'string' is not assignable to type 'Record<ReducerName, ReducerFunc>
```