### PR TITLE
Fixes existing type errors in component tests directory

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -269,13 +269,17 @@ export type PlotOptions = {
      */
     maxWidth?: string;
     /**
+     * force the plot into a fixed width
+     */
+    width?: number;
+    /**
      * force the plot into a fixed height
      */
     height: 'auto' | number | ((d: number) => number);
     /**
      * Convenience option for setting all four margins at once, in px.
      */
-    margin: number;
+    margin: number | { top?: number; right?: number; bottom?: number; left?: number };
     /**
      * Left margin of the plot, in px.
      */
@@ -346,7 +350,7 @@ export type PlotOptions = {
      * Options for the shared radius scale
      */
     r: ScaleOptions;
-    color: ColorScaleOptions;
+    color: Partial<ColorScaleOptions>;
     opacity: ScaleOptions;
     symbol: LegendScaleOptions;
     length: ScaleOptions;
@@ -372,6 +376,10 @@ export type PlotOptions = {
      */
     overlay: Snippet;
     facetAxes: Snippet;
+    /**
+     * A background color
+     */
+    background: string;
     /**
      * if you set testid, the plot container will get a data-testid attribute which
      * can be useful for automatic testing

--- a/src/tests/arrow.test.svelte
+++ b/src/tests/arrow.test.svelte
@@ -1,6 +1,8 @@
-<script>
+<script lang="ts">
     import { Arrow, Plot } from 'svelteplot';
-    let args = $props();
+    import type { ComponentProps } from 'svelte';
+
+    let args: ComponentProps<typeof Arrow> = $props();
 </script>
 
 <Plot width={100} height={100} axes={false}>

--- a/src/tests/arrow.test.ts
+++ b/src/tests/arrow.test.ts
@@ -67,7 +67,7 @@ describe('Arrow mark', () => {
         const arrows = container.querySelectorAll('g.arrow > g > path');
         expect(arrows.length).toBeGreaterThan(0);
 
-        const mainPath = arrows[0];
+        const mainPath = arrows[0] as SVGElement;
         expect(mainPath?.style.stroke).toBe('red');
         expect(mainPath?.style.strokeWidth).toBe('3px');
     });

--- a/src/tests/barX.test.svelte
+++ b/src/tests/barX.test.svelte
@@ -1,6 +1,13 @@
-<script>
+<script lang="ts">
     import { BarX, Plot } from 'svelteplot';
-    let { plotArgs, barArgs } = $props();
+    import type { ComponentProps } from 'svelte';
+
+    interface Props {
+        plotArgs: ComponentProps<typeof Plot>;
+        barArgs: ComponentProps<typeof BarX>;
+    }
+    
+    let { plotArgs, barArgs }: Props = $props();
 </script>
 
 <Plot width={100} height={100} axes={false} {...plotArgs}>

--- a/src/tests/barX.test.ts
+++ b/src/tests/barX.test.ts
@@ -22,7 +22,7 @@ describe('BarX mark', () => {
                 plotArgs: {},
                 barArgs: {
                     data: [1, 2, 3, 4, 5],
-                    strokeWidth: d => d
+                    strokeWidth: (d: any) => d
                 }
             }
         });

--- a/src/tests/barY.test.svelte
+++ b/src/tests/barY.test.svelte
@@ -1,6 +1,13 @@
-<script>
+<script lang="ts">
     import { BarY, Plot } from 'svelteplot';
-    let { plotArgs, barArgs } = $props();
+    import type { ComponentProps } from 'svelte';
+
+    interface Props {
+        plotArgs: ComponentProps<typeof Plot>;
+        barArgs: ComponentProps<typeof BarY>;
+    }
+
+    let { plotArgs, barArgs }: Props = $props();
 </script>
 
 <Plot width={100} height={100} axes={false} {...plotArgs}>

--- a/src/tests/barY.test.ts
+++ b/src/tests/barY.test.ts
@@ -3,7 +3,6 @@ import { render } from '@testing-library/svelte';
 import BarYTest from './barY.test.svelte';
 import ResizeObserver from 'resize-observer-polyfill';
 import { groupBy } from 'es-toolkit';
-import { stackY } from '$lib/index.js';
 
 global.ResizeObserver = ResizeObserver;
 
@@ -14,7 +13,7 @@ describe('BarY mark', () => {
                 plotArgs: {},
                 barArgs: {
                     data: [1, 2, 3, 4, 5],
-                    strokeWidth: d => d
+                    strokeWidth: (d: any) => d
                 }
             }
         });

--- a/src/tests/gridX.test.svelte
+++ b/src/tests/gridX.test.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { GridX, Plot } from 'svelteplot';
-  let { plotArgs, gridArgs } = $props();
+  import type { ComponentProps } from 'svelte';
+
+  interface Props {
+    plotArgs: ComponentProps<typeof Plot>;
+    gridArgs: ComponentProps<typeof GridX>;
+  }
+  
+  let { plotArgs, gridArgs }: Props = $props();
 </script>
 
 <Plot width={100} height={100} axes={false} {...plotArgs}>

--- a/src/tests/gridY.test.svelte
+++ b/src/tests/gridY.test.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import { GridY, Plot } from 'svelteplot';
-  let { plotArgs, gridArgs } = $props();
+  import type { ComponentProps } from 'svelte';
+  
+  interface Props {
+    plotArgs: ComponentProps<typeof Plot>;
+    gridArgs: ComponentProps<typeof GridY>;
+  }
+
+  let { plotArgs, gridArgs }: Props = $props();
 </script>
 
 <Plot width={100} height={100} axes={false} {...plotArgs}>

--- a/src/tests/line.test.svelte
+++ b/src/tests/line.test.svelte
@@ -1,6 +1,8 @@
-<script>
+<script lang="ts">
     import { Line, Plot } from 'svelteplot';
-    let args = $props();
+    import type { ComponentProps } from 'svelte';
+
+    let args: ComponentProps<typeof Line> = $props();
 </script>
 
 <Plot width={100} height={100} axes={false}>

--- a/src/tests/line.test.ts
+++ b/src/tests/line.test.ts
@@ -38,7 +38,7 @@ describe('Line mark', () => {
             }
         });
 
-        const lines = container.querySelectorAll('g.lines > g > path');
+        const lines = container.querySelectorAll('g.lines > g > path') as NodeListOf<SVGPathElement>;
         expect(lines).toHaveLength(1);
         expect(lines[0]?.getAttribute('d')).toBe(
             'M1,95L8.917,80C16.833,65,32.667,35,48.5,27.5C64.333,20,80.167,35,88.083,42.5L96,50'
@@ -81,7 +81,7 @@ describe('Line mark', () => {
             }
         });
 
-        const lines = container.querySelectorAll('g.lines > g > path');
+        const lines = container.querySelectorAll('g.lines > g > path') as NodeListOf<SVGPathElement>;
         expect(lines).toHaveLength(1);
         const line = lines[0];
         expect(line?.getAttribute('d')).toBe('M1,95L48.5,50L96,5');
@@ -105,7 +105,7 @@ describe('Line mark', () => {
         });
 
         // The implementation might differ from our expectation - look for any path elements
-        const paths = container.querySelectorAll('g.lines > g > path');
+        const paths = container.querySelectorAll('g.lines > g > path') as NodeListOf<SVGPathElement>;;
         expect(paths.length).toBeGreaterThan(0);
 
         // Check if at least one path has the expected styles
@@ -150,7 +150,7 @@ describe('Line mark', () => {
             }
         });
 
-        const text = container.querySelector('g.lines > g > text');
+        const text = container.querySelector('g.lines > g > text') as SVGTextElement;
         expect(text).not.toBeNull();
         expect(text?.textContent).toBe('Line Label');
         // The fill might be applied differently or through a different attribute
@@ -174,7 +174,7 @@ describe('Line mark', () => {
             }
         });
 
-        const text = container.querySelector('g.lines > g > text');
+        const text = container.querySelector('g.lines > g > text') as SVGTextElement;
         expect(text).not.toBeNull();
         expect(text?.textContent).toBe('Line Label');
         // The fill might be applied differently or through a different attribute
@@ -217,7 +217,7 @@ describe('Line mark', () => {
             }
         });
 
-        const lines = container.querySelectorAll('g.lines > g > path');
+        const lines = container.querySelectorAll('g.lines > g > path') as NodeListOf<SVGPathElement>;
         expect(lines).toHaveLength(2);
         // Verify we have two distinct lines with different stroke colors
         expect(lines[0]?.style.stroke).not.toBe(lines[1]?.style.stroke);

--- a/src/tests/plot.test.svelte
+++ b/src/tests/plot.test.svelte
@@ -1,6 +1,8 @@
-<script>
+<script lang="ts">
     import { Plot } from 'svelteplot';
-    let args = $props();
+    import type { ComponentProps } from 'svelte';
+
+    let args: ComponentProps<typeof Plot> = $props();
 </script>
 
 <Plot {...args} />

--- a/src/tests/polyfill.d.ts
+++ b/src/tests/polyfill.d.ts
@@ -1,0 +1,7 @@
+declare module 'resize-observer-polyfill' {
+  const ResizeObserver: {
+    new (callback: ResizeObserverCallback): ResizeObserver;
+    prototype: ResizeObserver;
+  };
+  export default ResizeObserver;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,
-        "moduleResolution": "NodeNext",
-        "module": "NodeNext"
+        "moduleResolution": "bundler",
+		"module": "esnext"
     }
     // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
     //


### PR DESCRIPTION
## What's in this PR?

Closes existing type errors in the `tests/` directory, with a couple knock-ons:

- Updates the tsconfig compilerOptions back to their default `moduleResolution` settings, which fixed typescript aliasing `svelteplot` to the built directory and instead follows the alias defined in `svelte.config.js` back to `src/lib/`.
- Adds a module type d.ts for `resize-observer-polyfill`.
- Adds a few missing `Plot` props used in tests to the `PlotOptions` type.

## Why?

This is basically just to get a toehold into some of the type issues in the library. Figure if the component-level tests are typed, that will surface the shouty errors typescript will direct at users, then community folks like me can add test cases for the props that should be typed, close those errors and get tests for their functionality as a bonus.