### PR TITLE
Make plot options partial to fix type errors

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -349,11 +349,11 @@ export type PlotOptions = {
     /**
      * Options for the shared radius scale
      */
-    r: ScaleOptions;
+    r: Partial<ScaleOptions>;
     color: Partial<ColorScaleOptions>;
-    opacity: ScaleOptions;
-    symbol: LegendScaleOptions;
-    length: ScaleOptions;
+    opacity: Partial<ScaleOptions>;
+    symbol: Partial<LegendScaleOptions>;
+    length: Partial<ScaleOptions>;
     fx: Partial<ScaleOptions>;
     fy: Partial<ScaleOptions>;
     children: Snippet<


### PR DESCRIPTION
These options for `Plot` should be intended to be specified partially. `color` was already fixed in https://github.com/svelteplot/svelteplot/pull/11, so this pull request addresses the rest.

By the way, does it make sense to make the properties optional in these `*Options` rather than always requiring `Partial<>`? (disclaimer: I'm not very familiar with Typescript, so sorry if I'm suggesting something not clever)