### PR TITLE
fix: restore reactivitiy in DotCanvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
         "typedoc-plugin-markdown": "^4.6.3",
         "typescript": "^5.8.3",
         "vite": "^6.3.5",
-        "vitest": "^3.1.3"
+        "vitest": "^3.1.3",
+        "vitest-matchmedia-mock": "^2.0.3"
     },
     "types": "./dist/index.d.ts",
     "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))
       '@sveltepress/theme-default':
         specifier: ^6.0.3
-        version: 6.0.3(4d262232ad1d154e3240867cfb036ad1)
+        version: 6.0.3(8842574121344738c5d79b13fa3b12b2)
       '@sveltepress/twoslash':
         specifier: ^1.2.2
         version: 1.2.2(svelte@5.30.1)(typescript@5.8.3)
@@ -207,6 +207,9 @@ importers:
       vitest:
         specifier: ^3.1.3
         version: 3.1.3(@types/debug@4.1.12)(@types/node@20.10.8)(jiti@1.21.0)(jsdom@26.1.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)
+      vitest-matchmedia-mock:
+        specifier: ^2.0.3
+        version: 2.0.3(@types/debug@4.1.12)(@types/node@20.10.8)(jiti@1.21.0)(jsdom@26.1.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)
 
 packages:
 
@@ -377,6 +380,10 @@ packages:
     resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-plugin-utils@7.27.1':
+    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-remap-async-to-generator@7.22.20':
     resolution: {integrity: sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==}
     engines: {node: '>=6.9.0'}
@@ -486,8 +493,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-import-attributes@7.23.3':
-    resolution: {integrity: sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==}
+  '@babel/plugin-syntax-import-attributes@7.27.1':
+    resolution: {integrity: sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1750,6 +1757,18 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.20.7':
+    resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -4641,6 +4660,9 @@ packages:
       vite:
         optional: true
 
+  vitest-matchmedia-mock@2.0.3:
+    resolution: {integrity: sha512-Oa2fI+dfaqcs67D08PqBL0D+Ymm4MYGZn1WimUgfZGDxp9/eb8gl6xqPmhjyrV3p9KdhKj2tp6E1b4YWiSg1lw==}
+
   vitest@3.1.3:
     resolution: {integrity: sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -5011,7 +5033,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -5058,6 +5080,8 @@ snapshots:
       '@babel/types': 7.25.2
 
   '@babel/helper-plugin-utils@7.24.8': {}
+
+  '@babel/helper-plugin-utils@7.27.1': {}
 
   '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.25.2)':
     dependencies:
@@ -5124,12 +5148,12 @@ snapshots:
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.25.2)
     transitivePeerDependencies:
@@ -5139,7 +5163,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.2)':
     dependencies:
@@ -5148,47 +5172,47 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -5198,42 +5222,42 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.25.2)':
     dependencies:
@@ -5244,18 +5268,18 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-async-generator-functions@7.23.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.25.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
 
@@ -5263,7 +5287,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.25.2)
     transitivePeerDependencies:
       - supports-color
@@ -5271,18 +5295,18 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5290,7 +5314,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.2)
     transitivePeerDependencies:
       - supports-color
@@ -5302,7 +5326,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
@@ -5312,47 +5336,47 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.25.0
 
   '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-dotall-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-dynamic-import@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
 
   '@babel/plugin-transform-exponentiation-operator@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-export-namespace-from@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
 
   '@babel/plugin-transform-for-of@7.23.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -5362,35 +5386,35 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-json-strings@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
 
   '@babel/plugin-transform-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-logical-assignment-operators@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
 
   '@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5408,7 +5432,7 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -5417,7 +5441,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5425,23 +5449,23 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-new-target@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
 
   '@babel/plugin-transform-numeric-separator@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
 
   '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.25.2)':
@@ -5449,14 +5473,14 @@ snapshots:
       '@babel/compat-data': 7.25.2
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.25.2)
 
   '@babel/plugin-transform-object-super@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)
     transitivePeerDependencies:
       - supports-color
@@ -5464,13 +5488,13 @@ snapshots:
   '@babel/plugin-transform-optional-catch-binding@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
 
   '@babel/plugin-transform-optional-chaining@7.23.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
     transitivePeerDependencies:
@@ -5479,13 +5503,13 @@ snapshots:
   '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5494,7 +5518,7 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.2)
     transitivePeerDependencies:
       - supports-color
@@ -5502,28 +5526,28 @@ snapshots:
   '@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-regenerator@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       regenerator-transform: 0.15.2
 
   '@babel/plugin-transform-reserved-words@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-spread@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
       - supports-color
@@ -5531,17 +5555,17 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-typescript@7.25.2(@babel/core@7.25.2)':
     dependencies:
@@ -5557,32 +5581,32 @@ snapshots:
   '@babel/plugin-transform-unicode-escapes@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-unicode-property-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-unicode-sets-regex@7.23.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/preset-env@7.23.8(@babel/core@7.25.2)':
     dependencies:
       '@babel/compat-data': 7.25.2
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.24.8
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.23.3(@babel/core@7.25.2)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.23.3(@babel/core@7.25.2)
@@ -5594,7 +5618,7 @@ snapshots:
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-import-assertions': 7.23.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-import-attributes': 7.23.3(@babel/core@7.25.2)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.25.2)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
@@ -5666,7 +5690,7 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/types': 7.25.2
       esutils: 2.0.3
 
@@ -6158,12 +6182,14 @@ snapshots:
 
   '@polka/url@1.0.0-next.24': {}
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.25.2)(rollup@2.79.1)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@2.79.1)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-module-imports': 7.24.7
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       rollup: 2.79.1
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
     transitivePeerDependencies:
       - supports-color
 
@@ -6406,7 +6432,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltepress/theme-default@6.0.3(4d262232ad1d154e3240867cfb036ad1)':
+  '@sveltepress/theme-default@6.0.3(8842574121344738c5d79b13fa3b12b2)':
     dependencies:
       '@docsearch/css': 3.5.2
       '@docsearch/js': 3.5.2(@algolia/client-search@4.22.1)(search-insights@2.13.0)
@@ -6416,7 +6442,7 @@ snapshots:
       '@sveltepress/twoslash': 1.2.2(svelte@5.30.1)(typescript@5.8.3)
       '@sveltepress/vite': 1.2.2(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(rollup@2.79.1)(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))
       '@unocss/extractor-svelte': 0.61.9
-      '@vite-pwa/sveltekit': 0.6.6(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(vite-plugin-pwa@0.19.0(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))(workbox-build@7.0.0)(workbox-window@7.0.0))
+      '@vite-pwa/sveltekit': 0.6.6(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(vite-plugin-pwa@0.19.0(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0))
       lru-cache: 10.4.3
       mdast-util-from-markdown: 2.0.0
       mdast-util-gfm: 3.0.0
@@ -6513,6 +6539,31 @@ snapshots:
       '@testing-library/dom': 10.4.0
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.25.3
+      '@babel/types': 7.25.2
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.7
+    optional: true
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.25.2
+    optional: true
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.25.3
+      '@babel/types': 7.25.2
+    optional: true
+
+  '@types/babel__traverse@7.20.7':
+    dependencies:
+      '@babel/types': 7.25.2
+    optional: true
 
   '@types/cookie@0.6.0': {}
 
@@ -6925,12 +6976,12 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vite-pwa/sveltekit@0.6.6(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(vite-plugin-pwa@0.19.0(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))(workbox-build@7.0.0)(workbox-window@7.0.0))':
+  '@vite-pwa/sveltekit@0.6.6(@sveltejs/kit@2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(vite-plugin-pwa@0.19.0(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0))':
     dependencies:
       '@sveltejs/kit': 2.21.0(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)))(svelte@5.30.1)(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))
       kolorist: 1.8.0
       tinyglobby: 0.2.13
-      vite-plugin-pwa: 0.19.0(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))(workbox-build@7.0.0)(workbox-window@7.0.0)
+      vite-plugin-pwa: 0.19.0(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0)
 
   '@vitest/expect@3.1.3':
     dependencies:
@@ -9934,13 +9985,13 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-pwa@0.19.0(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))(workbox-build@7.0.0)(workbox-window@7.0.0):
+  vite-plugin-pwa@0.19.0(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1))(workbox-build@7.0.0(@types/babel__core@7.20.5))(workbox-window@7.0.0):
     dependencies:
       debug: 4.4.0
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
       vite: 6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)
-      workbox-build: 7.0.0
+      workbox-build: 7.0.0(@types/babel__core@7.20.5)
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
@@ -9965,6 +10016,30 @@ snapshots:
   vitefu@1.0.4(vite@6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)):
     optionalDependencies:
       vite: 6.3.5(@types/node@20.10.8)(jiti@1.21.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)
+
+  vitest-matchmedia-mock@2.0.3(@types/debug@4.1.12)(@types/node@20.10.8)(jiti@1.21.0)(jsdom@26.1.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1):
+    dependencies:
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@20.10.8)(jiti@1.21.0)(jsdom@26.1.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1)
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@types/debug'
+      - '@types/node'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.1.3(@types/debug@4.1.12)(@types/node@20.10.8)(jiti@1.21.0)(jsdom@26.1.0)(sass@1.89.0)(terser@5.26.0)(tsx@4.16.5)(yaml@2.7.1):
     dependencies:
@@ -10066,13 +10141,13 @@ snapshots:
     dependencies:
       workbox-core: 7.0.0
 
-  workbox-build@7.0.0:
+  workbox-build@7.0.0(@types/babel__core@7.20.5):
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.12.0)
       '@babel/core': 7.25.2
       '@babel/preset-env': 7.23.8(@babel/core@7.25.2)
       '@babel/runtime': 7.23.8
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.25.2)(rollup@2.79.1)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.79.1)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)
       '@surma/rollup-plugin-off-main-thread': 2.2.3

--- a/src/lib/Mark.svelte
+++ b/src/lib/Mark.svelte
@@ -18,6 +18,7 @@
         ScaledDataRecord,
         ScaleType
     } from './types.js';
+    import { isEqual } from 'es-toolkit';
     import { getUsedScales, projectXY, projectX, projectY } from './helpers/scales.js';
     import { testFilter, isValid } from '$lib/helpers/index.js';
     import { resolveChannel, resolveProp } from './helpers/resolve.js';
@@ -106,6 +107,13 @@
     let added = false;
 
     $effect(() => {
+        const prevOptions = untrack(() => mark.options);
+        if (!isEqual(prevOptions, optionsWithAutoFacet)) {
+            mark.options = optionsWithAutoFacet;
+        }
+    });
+
+    $effect(() => {
         if (added) return;
         // without using untrack() here we end up with inexplicable
         // circular dependency updates resulting in a stack overflow
@@ -118,6 +126,7 @@
         );
         mark.data = untrack(() => data);
         mark.options = untrack(() => optionsWithAutoFacet);
+
         addMark(mark);
         added = true;
     });
@@ -225,6 +234,7 @@
                                       usedScales.y,
                                       suffix
                                   );
+
                         out[`x${suffix}`] = x;
                         out[`y${suffix}`] = y;
                         out.valid =
@@ -243,7 +253,7 @@
                 ScaleName
             ][]) {
                 // check if the mark has defined an accessor for this channel
-                if (options?.[channel] !== undefined && out[channel] === undefined) {
+                if (options?.[channel] != null && out[channel] === undefined) {
                     // resolve value
                     const value = row[channel];
 
@@ -256,6 +266,7 @@
                         : value;
 
                     out.valid = out.valid && isValid(value);
+
                     // apply dx/dy transform
                     out[channel] =
                         scale === 'x' && Number.isFinite(scaled) ? (scaled as number) + dx : scaled;

--- a/src/lib/helpers/scales.ts
+++ b/src/lib/helpers/scales.ts
@@ -134,16 +134,16 @@ export function computeScales(
 
     const projection = plotOptions.projection
         ? createProjection(
-              { projOptions: plotOptions.projection, inset: plotOptions.inset },
-              {
-                  width: plotWidth,
-                  height: plotHeight,
-                  marginBottom: plotOptions.marginBottom,
-                  marginLeft: plotOptions.marginLeft,
-                  marginRight: plotOptions.marginRight,
-                  marginTop: plotOptions.marginTop
-              }
-          )
+            { projOptions: plotOptions.projection, inset: plotOptions.inset },
+            {
+                width: plotWidth,
+                height: plotHeight,
+                marginBottom: plotOptions.marginBottom,
+                marginLeft: plotOptions.marginLeft,
+                marginRight: plotOptions.marginRight,
+                marginTop: plotOptions.marginTop
+            }
+        )
         : null;
     return { x, y, r, color, opacity, length, symbol, fx, fy, projection };
 }
@@ -168,6 +168,7 @@ export function createScale<T extends ScaleOptions>(
     const dataValues = new Set<RawValue>();
     const allDataValues: RawValue[] = [];
     const markTypes = new Set<MarkType>();
+
     const skip = new Map<ScaledChannelName, Set<symbol>>();
     let manualActiveMarks = 0;
     const propNames = new Set<string>();
@@ -212,8 +213,8 @@ export function createScale<T extends ScaleOptions>(
                             name === 'color'
                                 ? isColorOrNull
                                 : name === 'symbol'
-                                  ? isSymbolOrNull
-                                  : false;
+                                    ? isSymbolOrNull
+                                    : false;
 
                         let allValuesAreOutputType = !!isOutputType && mark.data.length > 0;
 
@@ -304,10 +305,10 @@ export function createScale<T extends ScaleOptions>(
             type === 'categorical' ||
             type === 'quantile' ||
             type === 'quantile-cont'
-          ? name === 'y'
-              ? valueArr.toReversed()
-              : valueArr
-          : extent(scaleOptions.zero ? [0, ...valueArr] : valueArr);
+            ? name === 'y'
+                ? valueArr.toReversed()
+                : valueArr
+            : extent(scaleOptions.zero ? [0, ...valueArr] : valueArr);
 
     if (!scaleOptions.scale) {
         throw new Error(`No scale function defined for ${name}`);
@@ -337,8 +338,8 @@ export function createScale<T extends ScaleOptions>(
             type === 'time'
                 ? null
                 : propNames.size === 1
-                  ? `${[...propNames.values()][0]}${type === 'log' ? ' (log)' : ''}`
-                  : null
+                    ? `${[...propNames.values()][0]}${type === 'log' ? ' (log)' : ''}`
+                    : null
     };
 }
 
@@ -415,8 +416,8 @@ export function getUsedScales(
             return [
                 channel,
                 !skipMarks.has(mark.id) &&
-                    toChannelOption(channel, options[channel]).scale !== null &&
-                    !plot.scales[scale].isDummy
+                toChannelOption(channel, options[channel]).scale !== null &&
+                !plot.scales[scale].isDummy
             ];
         })
     ) as { [k in ScaledChannelName]: boolean };
@@ -470,8 +471,8 @@ export function projectX(channel: 'x' | 'x1' | 'x2', scales: PlotScales, value: 
         (channel === 'x' && scales.x.type === 'band'
             ? scales.x.fn.bandwidth() * 0.5
             : channel === 'x2' && scales.x.type === 'band'
-              ? scales.x.fn.bandwidth()
-              : 0)
+                ? scales.x.fn.bandwidth()
+                : 0)
     );
 }
 
@@ -481,7 +482,7 @@ export function projectY(channel: 'y' | 'y1' | 'y2', scales: PlotScales, value: 
         (channel === 'y' && scales.y.type === 'band'
             ? scales.y.fn.bandwidth() * 0.5
             : channel === 'y2' && scales.y.type === 'band'
-              ? scales.y.fn.bandwidth()
-              : 0)
+                ? scales.y.fn.bandwidth()
+                : 0)
     );
 }

--- a/src/lib/helpers/typeChecks.test.ts
+++ b/src/lib/helpers/typeChecks.test.ts
@@ -17,6 +17,7 @@ describe('isColorOrNull', () => {
 
     it('returns true for "currentColor"', () => {
         expect(isColorOrNull('currentColor')).toBe(true);
+        expect(isColorOrNull('currentcolor')).toBe(true);
     });
 
     it('returns true for valid CSS variable', () => {

--- a/src/lib/helpers/typeChecks.ts
+++ b/src/lib/helpers/typeChecks.ts
@@ -44,18 +44,19 @@ export function isSymbolOrNull(v: RawValue | null | undefined) {
 }
 
 export function isColorOrNull(v: RawValue | null | undefined) {
-    return (
-        v == null ||
-        (typeof v === 'string' &&
-            (v === 'currentColor' ||
-                CSS_VAR.test(v) ||
-                CSS_COLOR.test(v) ||
-                CSS_COLOR_MIX.test(v) ||
-                CSS_COLOR_CONTRAST.test(v) ||
-                CSS_RGBA.test(v) ||
-                CSS_URL.test(v) ||
-                color(v) !== null))
-    );
+    if (v == null) return true;
+    if (typeof v === 'string') {
+        v = `${v}`.toLowerCase();
+        return (v === 'currentcolor' ||
+            CSS_VAR.test(v) ||
+            CSS_COLOR.test(v) ||
+            CSS_COLOR_MIX.test(v) ||
+            CSS_COLOR_CONTRAST.test(v) ||
+            CSS_RGBA.test(v) ||
+            CSS_URL.test(v) ||
+            color(v) !== null)
+    }
+    return false;
 }
 
 export function isOpacityOrNull(v: RawValue) {

--- a/src/lib/marks/Dot.svelte
+++ b/src/lib/marks/Dot.svelte
@@ -53,7 +53,7 @@
     }: DotProps = $props();
 
     const { getPlotState } = getContext<PlotContext>('svelteplot');
-    let plot = $derived(getPlotState());
+    const plot = $derived(getPlotState());
 
     function getSymbolPath(symbolType, size) {
         return d3Symbol(maybeSymbol(symbolType), size)();
@@ -96,7 +96,7 @@
     {#snippet children({ mark, usedScales, scaledData })}
         <g class="dots {className || ''}">
             {#if canvas}
-                <DotCanvas data={scaledData} {mark} {plot} {testFacet} {usedScales} />
+                <DotCanvas data={scaledData} {mark} />
             {:else}
                 {#each scaledData as d}
                     {#if d.valid && isValid(d.r)}

--- a/src/lib/marks/Dot.svelte
+++ b/src/lib/marks/Dot.svelte
@@ -96,7 +96,7 @@
     {#snippet children({ mark, usedScales, scaledData })}
         <g class="dots {className || ''}">
             {#if canvas}
-                <DotCanvas data={args.data} {mark} {plot} {testFacet} {usedScales} />
+                <DotCanvas data={scaledData} {mark} {plot} {testFacet} {usedScales} />
             {:else}
                 {#each scaledData as d}
                     {#if d.valid && isValid(d.r)}

--- a/src/lib/marks/helpers/CanvasLayer.svelte
+++ b/src/lib/marks/helpers/CanvasLayer.svelte
@@ -1,17 +1,34 @@
 <script lang="ts">
+    import { getContext } from 'svelte';
+    import type { PlotContext } from 'svelteplot/types';
+
     let {
-        canvas = $bindable(),
         devicePixelRatio = $bindable(1),
-        plot
+        ...restProps
     }: {
-        canvas: HTMLCanvasElement;
         devicePixelRatio: number;
-        plot: PlotState;
     } = $props();
 
+    const { getPlotState } = getContext<PlotContext>('svelteplot');
+    const plot = $derived(getPlotState());
+
+    // code from https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
+    let remove: null | (() => void) = null;
+
+    function updatePixelRatio() {
+        if (remove != null) {
+            remove();
+        }
+        const mqString = `(resolution: ${window.devicePixelRatio}dppx)`;
+        const media = matchMedia(mqString);
+        media.addEventListener('change', updatePixelRatio);
+        remove = () => {
+            media.removeEventListener('change', updatePixelRatio);
+        };
+        devicePixelRatio = window.devicePixelRatio;
+    }
     $effect(() => {
-        devicePixelRatio = window.devicePixelRatio || 1;
-        const ctx = canvas.getContext('2d');
+        updatePixelRatio();
     });
 </script>
 
@@ -24,7 +41,7 @@
 <foreignObject x="0" y="0" width={plot.width} height={plot.height}>
     <canvas
         xmlns="http://www.w3.org/1999/xhtml"
-        bind:this={canvas}
+        {...restProps}
         width={plot.width * devicePixelRatio}
         height={plot.height * devicePixelRatio}
         style="width: {plot.width}px; height: {plot.height}px;"></canvas>

--- a/src/lib/marks/helpers/CanvasLayer.svelte
+++ b/src/lib/marks/helpers/CanvasLayer.svelte
@@ -1,35 +1,12 @@
 <script lang="ts">
     import { getContext } from 'svelte';
     import type { PlotContext } from 'svelteplot/types';
+    import { devicePixelRatio } from 'svelte/reactivity/window';
 
-    let {
-        devicePixelRatio = $bindable(1),
-        ...restProps
-    }: {
-        devicePixelRatio: number;
-    } = $props();
+    let restProps: {} = $props();
 
     const { getPlotState } = getContext<PlotContext>('svelteplot');
     const plot = $derived(getPlotState());
-
-    // code from https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
-    let remove: null | (() => void) = null;
-
-    function updatePixelRatio() {
-        if (remove != null) {
-            remove();
-        }
-        const mqString = `(resolution: ${window.devicePixelRatio}dppx)`;
-        const media = matchMedia(mqString);
-        media.addEventListener('change', updatePixelRatio);
-        remove = () => {
-            media.removeEventListener('change', updatePixelRatio);
-        };
-        devicePixelRatio = window.devicePixelRatio;
-    }
-    $effect(() => {
-        updatePixelRatio();
-    });
 </script>
 
 <!-- 
@@ -42,8 +19,8 @@
     <canvas
         xmlns="http://www.w3.org/1999/xhtml"
         {...restProps}
-        width={plot.width * devicePixelRatio}
-        height={plot.height * devicePixelRatio}
+        width={plot.width * (devicePixelRatio.current ?? 1)}
+        height={plot.height * (devicePixelRatio.current ?? 1)}
         style="width: {plot.width}px; height: {plot.height}px;"></canvas>
 </foreignObject>
 

--- a/src/lib/marks/helpers/DotCanvas.svelte
+++ b/src/lib/marks/helpers/DotCanvas.svelte
@@ -1,24 +1,31 @@
 <script lang="ts">
-    import type { PlotState, Mark, BaseMarkProps, ScaledDataRecord } from '$lib/types.js';
+    import type {
+        PlotState,
+        Mark,
+        BaseMarkProps,
+        ScaledDataRecord,
+        PlotContext
+    } from '$lib/types.js';
     import { CSS_VAR } from '$lib/constants.js';
     import { resolveProp } from '$lib/helpers/resolve.js';
     import { maybeSymbol } from '$lib/helpers/symbols.js';
     import { symbol as d3Symbol } from 'd3-shape';
     import type { Attachment } from 'svelte/attachments';
+    import CanvasLayer from './CanvasLayer.svelte';
+    import { getContext } from 'svelte';
 
     let devicePixelRatio = $state(1);
 
+    const { getPlotState } = getContext<PlotContext>('svelteplot');
+    const plot = $derived(getPlotState());
+
     let {
         mark,
-        plot,
-        data,
-        usedScales
+        data
     }: {
         mark: Mark<BaseMarkProps>;
         plot: PlotState;
         data: ScaledDataRecord[];
-        testFacet: any;
-        usedScales: any;
     } = $props();
 
     function drawSymbolPath(symbolType: string, size: number, context) {
@@ -32,7 +39,6 @@
         const context = canvas.getContext('2d');
 
         $effect(() => {
-            usedScales;
             if (context) {
                 context.resetTransform();
                 context.scale(devicePixelRatio, devicePixelRatio);
@@ -97,39 +103,6 @@
             };
         });
     };
-
-    // code from https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
-    let remove: null | (() => void) = null;
-
-    function updatePixelRatio() {
-        if (remove != null) {
-            remove();
-        }
-        const mqString = `(resolution: ${window.devicePixelRatio}dppx)`;
-        const media = matchMedia(mqString);
-        media.addEventListener('change', updatePixelRatio);
-        remove = () => {
-            media.removeEventListener('change', updatePixelRatio);
-        };
-        devicePixelRatio = window.devicePixelRatio;
-    }
-    $effect(() => {
-        updatePixelRatio();
-    });
 </script>
 
-<foreignObject x="0" y="0" width={plot.width} height={plot.height}>
-    <canvas
-        xmlns="http://www.w3.org/1999/xhtml"
-        {@attach renderDots}
-        width={plot.width * devicePixelRatio}
-        height={plot.height * devicePixelRatio}
-        style="width: {plot.width}px; height: {plot.height}px;"></canvas>
-</foreignObject>
-
-<style>
-    foreignObject,
-    canvas {
-        color: currentColor;
-    }
-</style>
+<CanvasLayer bind:devicePixelRatio {@attach renderDots} />

--- a/src/lib/marks/helpers/DotCanvas.svelte
+++ b/src/lib/marks/helpers/DotCanvas.svelte
@@ -13,8 +13,7 @@
     import type { Attachment } from 'svelte/attachments';
     import CanvasLayer from './CanvasLayer.svelte';
     import { getContext } from 'svelte';
-
-    let devicePixelRatio = $state(1);
+    import { devicePixelRatio } from 'svelte/reactivity/window';
 
     const { getPlotState } = getContext<PlotContext>('svelteplot');
     const plot = $derived(getPlotState());
@@ -41,7 +40,7 @@
         $effect(() => {
             if (context) {
                 context.resetTransform();
-                context.scale(devicePixelRatio, devicePixelRatio);
+                context.scale(devicePixelRatio.current ?? 1, devicePixelRatio.current ?? 1);
 
                 for (const datum of data) {
                     if (datum.valid) {
@@ -97,12 +96,12 @@
                 context?.clearRect(
                     0,
                     0,
-                    plot.width * devicePixelRatio,
-                    plot.height * devicePixelRatio
+                    plot.width * (devicePixelRatio.current ?? 1),
+                    plot.height * (devicePixelRatio.current ?? 1)
                 );
             };
         });
     };
 </script>
 
-<CanvasLayer bind:devicePixelRatio {@attach renderDots} />
+<CanvasLayer {@attach renderDots} />

--- a/src/lib/marks/helpers/DotCanvas.svelte
+++ b/src/lib/marks/helpers/DotCanvas.svelte
@@ -12,7 +12,6 @@
         mark,
         plot,
         data,
-        testFacet,
         usedScales
     }: {
         mark: Mark<BaseMarkProps>;

--- a/src/lib/marks/helpers/DotCanvas.svelte
+++ b/src/lib/marks/helpers/DotCanvas.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
-    import type { PlotState, Mark, DataRecord, BaseMarkProps } from '$lib/types.js';
+    import type { PlotState, Mark, BaseMarkProps, ScaledDataRecord } from '$lib/types.js';
     import { CSS_VAR } from '$lib/constants.js';
-    import { isValid, testFilter } from '$lib/helpers/index.js';
-    import { resolveChannel, resolveProp, resolveScaledStyleProps } from '$lib/helpers/resolve.js';
-    import { projectXY } from '$lib/helpers/scales.js';
+    import { resolveProp } from '$lib/helpers/resolve.js';
     import { maybeSymbol } from '$lib/helpers/symbols.js';
     import { symbol as d3Symbol } from 'd3-shape';
-    import { untrack } from 'svelte';
-    import { isEqual } from 'es-toolkit';
+    import type { Attachment } from 'svelte/attachments';
 
-    let canvas: HTMLCanvasElement | undefined = $state();
     let devicePixelRatio = $state(1);
 
     let {
@@ -21,7 +17,7 @@
     }: {
         mark: Mark<BaseMarkProps>;
         plot: PlotState;
-        data: DataRecord[];
+        data: ScaledDataRecord[];
         testFacet: any;
         usedScales: any;
     } = $props();
@@ -31,121 +27,77 @@
         return d3Symbol(maybeSymbol(symbolType), size).context(context)();
     }
 
-    function scaleHash(scale) {
-        return { domain: scale.domain, type: scale.type, range: scale.range };
-    }
-
-    let _plotSize = $state([plot.width, plot.height]);
-    let _usedScales = $state(usedScales);
     let _markOptions = $state(mark.options);
-    const xScale = $derived(scaleHash(plot.scales.x));
-    const yScale = $derived(scaleHash(plot.scales.y));
-    const rScale = $derived(scaleHash(plot.scales.r));
-    let _xScale = $state(xScale);
-    let _yScale = $state(yScale);
-    let _rScale = $state(rScale);
 
-    const filteredData = $derived(
-        data.filter((datum) => testFilter(datum, _markOptions) && testFacet(datum, _markOptions))
-    );
-
-    let _filteredData: DataRecord[] = $state([]);
-
-    $effect(() => {
-        // update _usedScales only if changed
-        if (!isEqual(usedScales, _usedScales)) _usedScales = usedScales;
-        if (!isEqual(mark.options, _markOptions)) _markOptions = mark.options;
-
-        const plotSize = [plot.width, plot.height];
-        if (!isEqual(plotSize, _plotSize)) _plotSize = plotSize;
-
-        if (
-            _markOptions.filter
-                ? !isEqual(filteredData, _filteredData)
-                : filteredData.length !== _filteredData.length
-        ) {
-            _filteredData = filteredData;
-        }
-        if (!isEqual(xScale, _xScale)) _xScale = xScale;
-        if (!isEqual(yScale, _yScale)) _yScale = yScale;
-        if (!isEqual(rScale, _rScale)) _rScale = rScale;
-    });
-
-    $effect(() => {
-        // track plot size, since we're untracking the scales
-        _plotSize;
-        _markOptions;
-        _xScale;
-        _yScale;
-        _rScale;
-        const plotScales = untrack(() => plot.scales);
+    const renderDots: Attachment = (canvas: HTMLCanvasElement) => {
         const context = canvas.getContext('2d');
-        if (context === null) return;
-        // this will re-run whenever `color` or `size` change
-        context.resetTransform();
-        context.scale(devicePixelRatio, devicePixelRatio);
 
-        for (const datum of _filteredData) {
-            // untrack the filter test to avoid redrawing when not necessary
-            const x = resolveChannel('x', datum, _markOptions);
-            const y = resolveChannel('y', datum, _markOptions);
-            const r = resolveChannel('r', datum, _markOptions) || 2;
-            const symbol_ = resolveChannel('symbol', datum, {
-                symbol: 'circle',
-                ..._markOptions
-            });
-            const symbol = _usedScales.symbol ? plotScales.symbol.fn(symbol_) : symbol_;
+        $effect(() => {
+            usedScales;
+            if (context) {
+                context.resetTransform();
+                context.scale(devicePixelRatio, devicePixelRatio);
 
-            if (isValid(x) && isValid(y) && isValid(r)) {
-                const [px, py] = projectXY(plotScales, x, y, true, true);
+                for (const datum of data) {
+                    if (datum.valid) {
+                        let { fill, stroke } = datum;
 
-                const r_ = _usedScales.r ? plotScales.r.fn(r) : r;
-                const size = r_ * r_ * Math.PI * devicePixelRatio;
-                let { stroke, strokeOpacity, fillOpacity, fill, opacity } = resolveScaledStyleProps(
-                    datum,
-                    _markOptions,
-                    _usedScales,
-                    untrack(() => plot),
-                    'stroke'
-                );
+                        if (`${fill}`.toLowerCase() === 'currentcolor')
+                            fill = getComputedStyle(
+                                canvas?.parentElement?.parentElement
+                            ).getPropertyValue('color');
+                        if (`${stroke}`.toLowerCase() === 'currentcolor')
+                            stroke = getComputedStyle(
+                                canvas?.parentElement?.parentElement
+                            ).getPropertyValue('color');
 
-                if (`${fill}`.toLowerCase() === 'currentcolor')
-                    fill = getComputedStyle(canvas.parentElement.parentElement).getPropertyValue(
-                        'color'
-                    );
-                if (`${stroke}`.toLowerCase() === 'currentcolor')
-                    stroke = getComputedStyle(canvas.parentElement.parentElement).getPropertyValue(
-                        'color'
-                    );
-                if (CSS_VAR.test(fill))
-                    fill = getComputedStyle(canvas).getPropertyValue(fill.slice(4, -1));
-                if (CSS_VAR.test(stroke))
-                    stroke = getComputedStyle(canvas).getPropertyValue(stroke.slice(4, -1));
+                        if (CSS_VAR.test(fill))
+                            fill = getComputedStyle(canvas).getPropertyValue(fill.slice(4, -1));
+                        if (CSS_VAR.test(stroke))
+                            stroke = getComputedStyle(canvas).getPropertyValue(stroke.slice(4, -1));
 
-                if (stroke && stroke !== 'none') {
-                    const strokeWidth = resolveProp(_markOptions.strokeWidth, datum, 1.6);
-                    context.lineWidth = strokeWidth;
+                        if (stroke && stroke !== 'none') {
+                            const strokeWidth = resolveProp(
+                                _markOptions.strokeWidth,
+                                datum.datum,
+                                1.6
+                            );
+                            context.lineWidth = strokeWidth;
+                        }
+
+                        context.fillStyle = fill ? fill : 'none';
+                        context.strokeStyle = stroke ? stroke : 'none';
+                        context.translate(datum.x, datum.y);
+
+                        const size = datum.r * datum.r * Math.PI;
+
+                        context.beginPath();
+                        drawSymbolPath(datum.symbol, size, context);
+                        context.closePath();
+
+                        const { opacity = 1, fillOpacity = 1, strokeOpacity = 1 } = datum;
+
+                        if (opacity != null) context.globalAlpha = opacity ?? 1;
+                        if (fillOpacity != null) context.globalAlpha = (opacity ?? 1) * fillOpacity;
+                        if (fill && fill !== 'none') context.fill();
+                        if (strokeOpacity != null)
+                            context.globalAlpha = (opacity ?? 1) * strokeOpacity;
+                        if (stroke && stroke !== 'none') context.stroke();
+                        context.translate(-datum.x, -datum.y);
+                    }
                 }
-                context.fillStyle = fill ? fill : 'none';
-                context.strokeStyle = stroke ? stroke : 'none';
-                context.translate(px, py);
-
-                context.beginPath();
-                drawSymbolPath(symbol, size, context);
-                context.closePath();
-
-                if (opacity != null) context.globalAlpha = opacity ?? 1;
-                if (fillOpacity != null) context.globalAlpha = (opacity ?? 1) * fillOpacity;
-                if (fill && fill !== 'none') context.fill();
-                if (strokeOpacity != null) context.globalAlpha = (opacity ?? 1) * strokeOpacity;
-                if (stroke && stroke !== 'none') context.stroke();
-                context.translate(-px, -py);
             }
-        }
-        return () => {
-            canvas?.getContext('2d')?.clearRect(0, 0, canvas?.width, canvas?.height);
-        };
-    });
+
+            return () => {
+                context?.clearRect(
+                    0,
+                    0,
+                    plot.width * devicePixelRatio,
+                    plot.height * devicePixelRatio
+                );
+            };
+        });
+    };
 
     // code from https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
     let remove: null | (() => void) = null;
@@ -170,7 +122,7 @@
 <foreignObject x="0" y="0" width={plot.width} height={plot.height}>
     <canvas
         xmlns="http://www.w3.org/1999/xhtml"
-        bind:this={canvas}
+        {@attach renderDots}
         width={plot.width * devicePixelRatio}
         height={plot.height * devicePixelRatio}
         style="width: {plot.width}px; height: {plot.height}px;"></canvas>

--- a/src/routes/marks/dot/+page.md
+++ b/src/routes/marks/dot/+page.md
@@ -9,7 +9,7 @@ y↑ and fuel efficiency in miles per gallon in x→.
 ```svelte live
 <script>
     import { Plot, Dot, Pointer, RuleX } from 'svelteplot';
-    import Slider from '$lib/ui/Slider.svelte';
+    import { Checkbox, Slider } from '$lib/ui';
     import { page } from '$app/state';
 
     const { cars } = $derived(page.data.data);
@@ -23,8 +23,8 @@ y↑ and fuel efficiency in miles per gallon in x→.
     );
 </script>
 
-<input type="checkbox" bind:checked={fill} /> fill symbols<br />
-<input type="checkbox" bind:checked={canvas} /> use canvas<br />
+<Checkbox bind:value={fill} label="fill symbols" />
+<Checkbox bind:value={canvas} label="use canvas" /><br />
 
 <Slider
     label="max cylinders"
@@ -35,10 +35,11 @@ y↑ and fuel efficiency in miles per gallon in x→.
 <Plot grid height={500} testid="cars1">
     <Dot
         {canvas}
-        data={filteredCars}
+        filter={(d) => d.cylinders <= maxCylinders}
+        data={cars}
         x="economy (mpg)"
         y="power (hp)"
-        stroke="manufactor"
+        {...{ [fill ? 'fill' : 'stroke']: 'manufactor' }}
         symbol="manufactor" />
 </Plot>
 ```
@@ -50,6 +51,7 @@ When showing plots with a lot of dots, you can switch to canvas rendering to imp
     import { Plot, Dot } from 'svelteplot';
     import { range } from 'd3-array';
     import { randomNormal } from 'd3-random';
+    import { Checkbox } from '$lib/ui';
 
     const randX = randomNormal();
     const randY = randomNormal();
@@ -57,14 +59,13 @@ When showing plots with a lot of dots, you can switch to canvas rendering to imp
     let fill = $state(false);
 </script>
 
-<input type="checkbox" bind:checked={fill} /> fill symbols<br />
+<Checkbox bind:value={fill} label="fill symbol" />
 
 <Plot>
     <Dot
-        fill={fill ? 'currentColor' : null}
-        stroke={!fill ? 'currentColor' : null}
-        opacity={0.4}
         canvas
+        {...{ [fill ? 'fill' : 'stroke']: 'currentColor' }}
+        opacity={0.4}
         data={range(20000).map((i) => [
             randX(),
             randY()
@@ -181,7 +182,7 @@ Using the <b>DotY</b> mark, you can quickly plot a list of numbers as dots:
     let { cars } = $derived(page.data.data);
 </script>
 
-<Plot testid="doty">
+<Plot testid="doty" height={400}>
     <DotY data={cars.map((d) => d['economy (mpg)'])} />
 </Plot>
 ```
@@ -203,6 +204,7 @@ You can use the color channel for encoding a third quantitative variable.
 
 <Plot
     grid
+    height={400}
     color={{
         legend: false,
         type: 'linear',

--- a/src/tests/arrow.test.ts
+++ b/src/tests/arrow.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import ArrowTest from './arrow.test.svelte';
-import ResizeObserver from 'resize-observer-polyfill';
-
-global.ResizeObserver = ResizeObserver;
 
 describe('Arrow mark', () => {
     it('single arrow with basic properties', () => {

--- a/src/tests/barX.test.ts
+++ b/src/tests/barX.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import BarXTest from './barX.test.svelte';
-import ResizeObserver from 'resize-observer-polyfill';
-
-global.ResizeObserver = ResizeObserver;
 
 const testData = [{
     year: '2010',

--- a/src/tests/barY.test.ts
+++ b/src/tests/barY.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import BarYTest from './barY.test.svelte';
-import ResizeObserver from 'resize-observer-polyfill';
 import { groupBy } from 'es-toolkit';
-
-global.ResizeObserver = ResizeObserver;
 
 describe('BarY mark', () => {
     it('simple bar chart from number array', () => {

--- a/src/tests/brush.svelte.test.ts
+++ b/src/tests/brush.svelte.test.ts
@@ -2,10 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import { userEvent } from '@testing-library/user-event';
 import BrushTest from './brush.test.svelte';
-import ResizeObserver from 'resize-observer-polyfill';
 import { tick, type ComponentProps } from 'svelte';
 
-global.ResizeObserver = ResizeObserver;
 
 describe('Brush mark', () => {
     it('single brush with basic properties', async () => {

--- a/src/tests/gridX.test.ts
+++ b/src/tests/gridX.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import GridXTest from './gridX.test.svelte';
-import ResizeObserver from 'resize-observer-polyfill';
 
-global.ResizeObserver = ResizeObserver;
 
 describe('GridX mark', () => {
   it('simple x grid with stroke styles', () => {

--- a/src/tests/gridY.test.ts
+++ b/src/tests/gridY.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import GridYTest from './gridY.test.svelte';
-import ResizeObserver from 'resize-observer-polyfill';
-
-global.ResizeObserver = ResizeObserver;
 
 describe('GridY mark', () => {
   it('simple y grid with stroke styles', () => {

--- a/src/tests/line.test.ts
+++ b/src/tests/line.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, test } from 'vitest';
 import { render } from '@testing-library/svelte';
 import LineTest from './line.test.svelte';
-import ResizeObserver from 'resize-observer-polyfill';
-
-global.ResizeObserver = ResizeObserver;
 
 describe('Line mark', () => {
     it('single line', () => {

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -4,15 +4,12 @@ import type MatchMedia from 'vitest-matchmedia-mock';
 
 import { afterEach, beforeAll } from "vitest";
 
-let matchMedia: MatchMedia;
+let matchMedia: MatchMedia = new MatchMediaMock();
 
 beforeAll(() => {
     global.ResizeObserver = ResizeObserver;
-    matchMedia = new MatchMediaMock();
-
-    console.log('m', window.matchMedia);
 })
 
 afterEach(() => {
     matchMedia.clear();
-})
+});

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,18 @@
+import ResizeObserver from 'resize-observer-polyfill';
+import MatchMediaMock from 'vitest-matchmedia-mock';
+import type MatchMedia from 'vitest-matchmedia-mock';
+
+import { afterEach, beforeAll } from "vitest";
+
+let matchMedia: MatchMedia;
+
+beforeAll(() => {
+    global.ResizeObserver = ResizeObserver;
+    matchMedia = new MatchMediaMock();
+
+    console.log('m', window.matchMedia);
+})
+
+afterEach(() => {
+    matchMedia.clear();
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -75,7 +75,8 @@ export default defineConfig({
 
     test: {
         include: ['src/**/*.{test,spec}.{js,ts}'],
-        environment: 'jsdom'
+        environment: 'jsdom',
+        setupFiles: ['/src/tests/setup.ts']
     },
 
     css: {


### PR DESCRIPTION
Changes:
- use pre-scaledData instead of scaling data inside mark
- use `{@ attach}` instead of bind:this'ing canvas element 
- make color detection case-insensitive
- fix updating of mark.options!
- update examples
- reanimate CanvasLayer