### PR TITLE
feat: add gradient helpers LinearGradientX and LinearGradientY

### DIFF
--- a/config/sidebar.ts
+++ b/config/sidebar.ts
@@ -114,6 +114,10 @@ export default {
                 {
                     title: 'Defaults',
                     to: '/features/defaults/'
+                },
+                {
+                    title: 'Gradients',
+                    to: '/features/gradients/'
                 }
             ]
         }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -78,5 +78,7 @@ export { sort, shuffle, reverse } from './transforms/sort.js';
 export { stackX, stackY } from './transforms/stack.js';
 export { windowX, windowY } from './transforms/window.js';
 
-// format helpers
+// helpers
 export { formatMonth } from './helpers/formats.js';
+export { default as LinearGradientX } from './marks/helpers/LinearGradientX.svelte';
+export { default as LinearGradientY } from './marks/helpers/LinearGradientY.svelte';

--- a/src/lib/marks/Line.svelte
+++ b/src/lib/marks/Line.svelte
@@ -100,8 +100,6 @@
     const { getPlotState } = getContext<PlotContext>('svelteplot');
     const plot = $derived(getPlotState());
 
-    type LinePath = (dr: DataRecord[]) => string;
-
     const linePath: Line<ScaledDataRecord> = $derived(
         plot.scales.projection && curve === 'auto'
             ? sphereLine(plot.scales.projection)

--- a/src/lib/marks/helpers/DotCanvas.svelte
+++ b/src/lib/marks/helpers/DotCanvas.svelte
@@ -14,6 +14,7 @@
     import CanvasLayer from './CanvasLayer.svelte';
     import { getContext } from 'svelte';
     import { devicePixelRatio } from 'svelte/reactivity/window';
+    import { resolveColor } from './canvas';
 
     const { getPlotState } = getContext<PlotContext>('svelteplot');
     const plot = $derived(getPlotState());
@@ -46,19 +47,8 @@
                     if (datum.valid) {
                         let { fill, stroke } = datum;
 
-                        if (`${fill}`.toLowerCase() === 'currentcolor')
-                            fill = getComputedStyle(
-                                canvas?.parentElement?.parentElement
-                            ).getPropertyValue('color');
-                        if (`${stroke}`.toLowerCase() === 'currentcolor')
-                            stroke = getComputedStyle(
-                                canvas?.parentElement?.parentElement
-                            ).getPropertyValue('color');
-
-                        if (CSS_VAR.test(fill))
-                            fill = getComputedStyle(canvas).getPropertyValue(fill.slice(4, -1));
-                        if (CSS_VAR.test(stroke))
-                            stroke = getComputedStyle(canvas).getPropertyValue(stroke.slice(4, -1));
+                        fill = resolveColor(fill, canvas);
+                        stroke = resolveColor(stroke, canvas);
 
                         if (stroke && stroke !== 'none') {
                             const strokeWidth = resolveProp(

--- a/src/lib/marks/helpers/LineCanvas.svelte
+++ b/src/lib/marks/helpers/LineCanvas.svelte
@@ -6,7 +6,6 @@
         ScaledDataRecord,
         UsedScales
     } from '$lib/types.js';
-    import { CSS_VAR, CSS_URL } from '$lib/constants.js';
     import { resolveProp, resolveScaledStyleProps } from '$lib/helpers/resolve.js';
     import { getContext } from 'svelte';
     import { type Line } from 'd3-shape';

--- a/src/lib/marks/helpers/LineCanvas.svelte
+++ b/src/lib/marks/helpers/LineCanvas.svelte
@@ -6,13 +6,14 @@
         ScaledDataRecord,
         UsedScales
     } from '$lib/types.js';
-    import { CSS_VAR } from '$lib/constants.js';
+    import { CSS_VAR, CSS_URL } from '$lib/constants.js';
     import { resolveProp, resolveScaledStyleProps } from '$lib/helpers/resolve.js';
     import { getContext } from 'svelte';
     import { type Line } from 'd3-shape';
     import CanvasLayer from './CanvasLayer.svelte';
     import type { Attachment } from 'svelte/attachments';
     import { devicePixelRatio } from 'svelte/reactivity/window';
+    import { resolveColor } from './canvas';
 
     let {
         mark,
@@ -111,18 +112,6 @@
             };
         });
     }) as Attachment;
-
-    function resolveColor(color, canvas) {
-        if (`${color}`.toLowerCase() === 'currentcolor') {
-            color = getComputedStyle(
-                canvas?.parentElement?.parentElement as Element
-            ).getPropertyValue('color');
-        }
-        if (CSS_VAR.test(color)) {
-            color = getComputedStyle(canvas).getPropertyValue(color.slice(4, -1));
-        }
-        return color;
-    }
 </script>
 
 <CanvasLayer {@attach render} />

--- a/src/lib/marks/helpers/LinearGradientX.svelte
+++ b/src/lib/marks/helpers/LinearGradientX.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+    import { getContext } from 'svelte';
+    import type { PlotContext, RawValue } from 'svelteplot/types';
+
+    let {
+        id,
+        stops
+    }: {
+        id: string;
+        stops: { x: RawValue; color: string }[];
+    } = $props();
+
+    const { getPlotState } = getContext<PlotContext>('svelteplot');
+    const plot = $derived(getPlotState());
+
+    const projectedStops = $derived(
+        stops
+            .map((d) => ({ ...d, px: plot.scales.x.fn(d.x) / plot.width }))
+            .sort((a, b) => a.px - b.px)
+    );
+</script>
+
+<linearGradient {id} gradientUnits="userSpaceOnUse" x1={0} y2={0} y1={0} x2={plot.width}>
+    {#each projectedStops as { px, color }}
+        <stop stop-color={color} offset={px} />
+    {/each}
+</linearGradient>

--- a/src/lib/marks/helpers/LinearGradientY.svelte
+++ b/src/lib/marks/helpers/LinearGradientY.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+    import { getContext } from 'svelte';
+    import type { PlotContext, RawValue } from 'svelteplot/types';
+
+    let {
+        id,
+        stops
+    }: {
+        id: string;
+        stops: { y: RawValue; color: string }[];
+    } = $props();
+
+    const { getPlotState } = getContext<PlotContext>('svelteplot');
+    const plot = $derived(getPlotState());
+
+    const projectedStops = $derived(
+        stops
+            .map((d) => ({ ...d, py: plot.scales.y.fn(d.y) / plot.height }))
+            .sort((a, b) => a.py - b.py)
+    );
+</script>
+
+<linearGradient {id} gradientUnits="userSpaceOnUse" x1={0} x2={0} y1={0} y2={plot.height}>
+    {#each projectedStops as { py, color }}
+        <stop stop-color={color} offset={py} />
+    {/each}
+</linearGradient>

--- a/src/lib/marks/helpers/canvas.ts
+++ b/src/lib/marks/helpers/canvas.ts
@@ -1,0 +1,39 @@
+import { CSS_URL, CSS_VAR } from "svelteplot/constants";
+
+export function resolveColor(color: string, canvas: HTMLCanvasElement) {
+    if (`${color}`.toLowerCase() === 'currentcolor') {
+        color = getComputedStyle(
+            canvas?.parentElement?.parentElement as Element
+        ).getPropertyValue('color');
+    }
+    if (CSS_VAR.test(color)) {
+        color = getComputedStyle(canvas).getPropertyValue(color.slice(4, -1));
+    }
+    if (CSS_URL.test(color)) {
+        // might be a gradient we can parse!
+        const m = color.match(/^url\((#[^\)]+)\)/);
+        const gradientId = m[1];
+        const gradient = canvas.ownerDocument.querySelector(gradientId) as
+            | SVGLinearGradientElement
+            | SVGRadialGradientElement;
+        if (gradient) {
+            // parse gradient
+            if (gradient.nodeName === 'linearGradient') {
+                const x0 = +gradient.getAttribute('x1');
+                const x1 = +gradient.getAttribute('x2');
+                const y0 = +gradient.getAttribute('y1');
+                const y1 = +gradient.getAttribute('y2');
+                const ctxGradient = canvas
+                    .getContext('2d')
+                    .createLinearGradient(x0, y0, x1, y1);
+                for (const stop of gradient.querySelectorAll('stop')) {
+                    const offset = +stop.getAttribute('offset');
+                    const color = stop.getAttribute('stop-color');
+                    ctxGradient.addColorStop(offset, color);
+                }
+                return ctxGradient;
+            }
+        }
+    }
+    return color;
+}

--- a/src/lib/marks/helpers/canvas.ts
+++ b/src/lib/marks/helpers/canvas.ts
@@ -18,7 +18,7 @@ export function resolveColor(color: string, canvas: HTMLCanvasElement) {
             | SVGRadialGradientElement;
         if (gradient) {
             // parse gradient
-            if (gradient.nodeName === 'linearGradient') {
+            if (gradient.nodeName.toLowerCase() === 'lineargradient') {
                 const x0 = +gradient.getAttribute('x1');
                 const x1 = +gradient.getAttribute('x2');
                 const y0 = +gradient.getAttribute('y1');
@@ -28,7 +28,7 @@ export function resolveColor(color: string, canvas: HTMLCanvasElement) {
                     .createLinearGradient(x0, y0, x1, y1);
                 for (const stop of gradient.querySelectorAll('stop')) {
                     const offset = +stop.getAttribute('offset');
-                    const color = stop.getAttribute('stop-color');
+                    const color = resolveColor(stop.getAttribute('stop-color'), canvas);
                     ctxGradient.addColorStop(offset, color);
                 }
                 return ctxGradient;

--- a/src/routes/features/gradients/+page.md
+++ b/src/routes/features/gradients/+page.md
@@ -11,7 +11,7 @@ For horizontal gradients (= from left to right)
 **Options:**
 
 - **id** - the gradient id to be used in `url(#...)` fills and strokes
-- **stops** - a list of `({ y, color })` pairs, y in data coordinates
+- **stops** - a list of `({ x, color })` pairs, with x coordinates defined in data space
 
 ```svelte live
 <script lang="ts">
@@ -89,7 +89,7 @@ For vertical gradients (from top to bottom)
 **Options:**
 
 - **id** - the gradient id to be used in `url(#...)` fills and strokes
-- **stops** - a list of `({ y, color })` pairs, y in data coordinates
+- **stops** - a list of `({ y, color })` pairs, y coordinates defined in data space
 
 ```svelte live
 <script lang="ts">

--- a/src/routes/features/gradients/+page.md
+++ b/src/routes/features/gradients/+page.md
@@ -1,0 +1,148 @@
+---
+title: Gradients
+---
+
+While SveltePlot allows you to use any SVG gradients, you can also make use of the [LinearGradientX](#LinearGradientX) and [LinearGradientY](#LinearGradientY) helpers, which allow mapping data to gradient stops.
+
+## LinearGradientX
+
+For horizontal gradients (= from left to right)
+
+**Options:**
+
+- **id** - the gradient id to be used in `url(#...)` fills and strokes
+- **stops** - a list of `({ y, color })` pairs, y in data coordinates
+
+```svelte live
+<script lang="ts">
+    import {
+        Plot,
+        Line,
+        RuleY,
+        LinearGradientX
+    } from 'svelteplot';
+    import { page } from '$app/state';
+    let { aapl } = $derived(page.data.data);
+</script>
+
+<Plot height={250} x={{ grid: true }}>
+    <defs>
+        <LinearGradientX
+            id="gradientx"
+            stops={[
+                {
+                    x: new Date(2014, 0, 1),
+                    color: 'cyan'
+                },
+                {
+                    x: new Date(2016, 0, 1),
+                    color: 'magenta'
+                },
+
+                {
+                    x: new Date(2018, 0, 1),
+                    color: 'gold'
+                }
+            ]} />
+    </defs>
+    <Line
+        data={aapl}
+        x="Date"
+        y="Close"
+        stroke="url(#gradientx)" />
+</Plot>
+```
+
+```svelte
+<Plot height={250} x={{ grid: true }}>
+    <defs>
+        <LinearGradientX
+            id="gradientx"
+            stops={[
+                {
+                    x: new Date(2014, 0, 1),
+                    color: 'cyan'
+                },
+                {
+                    x: new Date(2016, 0, 1),
+                    color: 'magenta'
+                },
+
+                {
+                    x: new Date(2018, 0, 1),
+                    color: 'gold'
+                }
+            ]} />
+    </defs>
+    <Line
+        data={aapl}
+        x="Date"
+        y="Close"
+        stroke="url(#gradientx)" />
+</Plot>
+```
+
+## LinearGradientY
+
+For vertical gradients (from top to bottom)
+
+**Options:**
+
+- **id** - the gradient id to be used in `url(#...)` fills and strokes
+- **stops** - a list of `({ y, color })` pairs, y in data coordinates
+
+```svelte live
+<script lang="ts">
+    import {
+        Plot,
+        Line,
+        Frame,
+        LinearGradientX,
+        LinearGradientY
+    } from 'svelteplot';
+    import { page } from '$app/state';
+    let { aapl } = $derived(page.data.data);
+</script>
+
+<Plot y={{ grid: true }}>
+    <defs>
+        <LinearGradientY
+            id="gradient-y"
+            stops={[
+                { y: 180, color: 'cyan' },
+                { y: 140, color: 'magenta' },
+                { y: 100, color: 'magenta' },
+                { y: 80, color: 'gold' },
+                { y: 60, color: 'gold' }
+            ]} />
+    </defs>
+    <Line
+        data={aapl}
+        x="Date"
+        y="Close"
+        stroke="url(#gradient-y)" />
+    <Frame fill="url(#gradient-y)" opacity={0.1} />
+</Plot>
+```
+
+```svelte
+<Plot>
+    <defs>
+        <LinearGradientY
+            id="gradient-y"
+            stops={[
+                { y: 180, color: 'cyan' },
+                { y: 140, color: 'magenta' },
+                { y: 100, color: 'magenta' },
+                { y: 80, color: 'gold' },
+                { y: 60, color: 'gold' }
+            ]} />
+    </defs>
+    <Line
+        data={aapl}
+        x="Date"
+        y="Close"
+        stroke="url(#gradient-y)" />
+    <Frame fill="url(#gradient-y)" opacity={0.1} />
+</Plot>
+```

--- a/src/routes/features/gradients/+page.md
+++ b/src/routes/features/gradients/+page.md
@@ -101,27 +101,23 @@ For vertical gradients (from top to bottom)
         LinearGradientY
     } from 'svelteplot';
     import { page } from '$app/state';
-    let { aapl } = $derived(page.data.data);
+    let { sftemp } = $derived(page.data.data);
 </script>
 
-<Plot y={{ grid: true }}>
+<Plot marginRight={10} height={250} y={{ grid: true }}>
     <defs>
         <LinearGradientY
             id="gradient-y"
             stops={[
-                { y: 180, color: 'cyan' },
-                { y: 140, color: 'magenta' },
-                { y: 100, color: 'magenta' },
-                { y: 80, color: 'gold' },
-                { y: 60, color: 'gold' }
+                { y: 70, color: 'var(--svp-red)' },
+                { y: 50, color: 'var(--svp-blue)' }
             ]} />
     </defs>
     <Line
-        data={aapl}
-        x="Date"
-        y="Close"
+        data={sftemp}
+        x="date"
+        y="high"
         stroke="url(#gradient-y)" />
-    <Frame fill="url(#gradient-y)" opacity={0.1} />
 </Plot>
 ```
 
@@ -129,20 +125,16 @@ For vertical gradients (from top to bottom)
 <Plot>
     <defs>
         <LinearGradientY
-            id="gradient-y"
+            id="temp-gradient"
             stops={[
-                { y: 180, color: 'cyan' },
-                { y: 140, color: 'magenta' },
-                { y: 100, color: 'magenta' },
-                { y: 80, color: 'gold' },
-                { y: 60, color: 'gold' }
+                { y: 70, color: 'red' },
+                { y: 50, color: 'blue' }
             ]} />
     </defs>
     <Line
-        data={aapl}
-        x="Date"
-        y="Close"
-        stroke="url(#gradient-y)" />
-    <Frame fill="url(#gradient-y)" opacity={0.1} />
+        data={sftemp}
+        x="date"
+        y="high"
+        stroke="url(#temp-gradient)" />
 </Plot>
 ```

--- a/src/routes/features/gradients/+page.md
+++ b/src/routes/features/gradients/+page.md
@@ -117,6 +117,7 @@ For vertical gradients (from top to bottom)
         data={sftemp}
         x="date"
         y="high"
+        canvas
         stroke="url(#gradient-y)" />
 </Plot>
 ```
@@ -135,6 +136,7 @@ For vertical gradients (from top to bottom)
         data={sftemp}
         x="date"
         y="high"
+        canvas
         stroke="url(#temp-gradient)" />
 </Plot>
 ```

--- a/src/routes/features/gradients/+page.ts
+++ b/src/routes/features/gradients/+page.ts
@@ -1,0 +1,8 @@
+import { loadDatasets } from '$lib/helpers/data.js';
+import type { PageLoad } from './$types.js';
+
+export const load: PageLoad = async ({ fetch }) => {
+    return {
+        data: await loadDatasets(['penguins', 'aapl'], fetch)
+    };
+};

--- a/src/routes/features/gradients/+page.ts
+++ b/src/routes/features/gradients/+page.ts
@@ -3,6 +3,6 @@ import type { PageLoad } from './$types.js';
 
 export const load: PageLoad = async ({ fetch }) => {
     return {
-        data: await loadDatasets(['penguins', 'aapl'], fetch)
+        data: await loadDatasets(['sftemp', 'aapl'], fetch)
     };
 };

--- a/src/routes/marks/line/+page.md
+++ b/src/routes/marks/line/+page.md
@@ -767,3 +767,83 @@ Like all marks, Line marks support [faceting](/features/faceting). In this examp
     fx="Symbol" />
 />
 ```
+
+### Gradient line
+
+If you want lines with gradients
+
+```svelte live
+<script lang="ts">
+    import {
+        Plot,
+        Line,
+        RuleY,
+        LinearGradientX,
+        LinearGradientY
+    } from 'svelteplot';
+    import { page } from '$app/state';
+    let { aapl } = $derived(page.data.data);
+</script>
+
+<Plot marginTop={60} grid y={{ grid: true }}>
+    {#snippet children({ width, options, height, scales })}
+        <defs>
+            <LinearGradientY
+                id="rdbu-gradient"
+                stops={[
+                    { y: 300, color: 'yellow' },
+                    { y: 250, color: 'yellow' },
+                    { y: 200, color: 'green' },
+                    { y: 100.1, color: 'green' },
+                    { y: 100, color: 'red' }
+                ]} />
+            <LinearGradientX
+                id="gradient2"
+                stops={[
+                    {
+                        x: new Date(2014, 0, 1),
+                        color: 'cyan'
+                    },
+                    {
+                        x: new Date(2017, 0, 1),
+                        color: 'cyan'
+                    },
+                    {
+                        x: new Date(2017, 0, 2),
+                        color: 'magenta'
+                    },
+                    {
+                        x: new Date(2018, 0, 1),
+                        color: 'magenta'
+                    },
+                    {
+                        x: new Date(2018, 4, 1),
+                        color: 'white'
+                    }
+                ]} />
+        </defs>
+        <Line
+            data={aapl}
+            x="Date"
+            y="Close"
+            stroke="url(#rdbu-gradient)" />
+        <Line
+            data={aapl}
+            x="Date"
+            y={(d) => d.Close * 1.2}
+            canvas
+            stroke="url(#rdbu-gradient)" />
+        <Line
+            data={aapl}
+            x="Date"
+            y={(d) => d.Close * 2}
+            stroke="url(#gradient2)" />
+        <Line
+            data={aapl}
+            x="Date"
+            y={(d) => d.Close * 2.2}
+            canvas
+            stroke="url(#gradient2)" />
+    {/snippet}
+</Plot>
+```

--- a/src/routes/marks/line/+page.md
+++ b/src/routes/marks/line/+page.md
@@ -768,82 +768,54 @@ Like all marks, Line marks support [faceting](/features/faceting). In this examp
 />
 ```
 
-### Gradient line
+### Gradient lines
 
-If you want lines with gradients
+You can use the [LinearGradient](/features/gradients) helper components to color lines:
 
 ```svelte live
 <script lang="ts">
     import {
         Plot,
         Line,
-        RuleY,
+        Frame,
         LinearGradientX,
         LinearGradientY
     } from 'svelteplot';
     import { page } from '$app/state';
-    let { aapl } = $derived(page.data.data);
+    let { sftemp } = $derived(page.data.data);
 </script>
 
-<Plot marginTop={60} grid y={{ grid: true }}>
-    {#snippet children({ width, options, height, scales })}
-        <defs>
-            <LinearGradientY
-                id="rdbu-gradient"
-                stops={[
-                    { y: 300, color: 'yellow' },
-                    { y: 250, color: 'yellow' },
-                    { y: 200, color: 'green' },
-                    { y: 100.1, color: 'green' },
-                    { y: 100, color: 'red' }
-                ]} />
-            <LinearGradientX
-                id="gradient2"
-                stops={[
-                    {
-                        x: new Date(2014, 0, 1),
-                        color: 'cyan'
-                    },
-                    {
-                        x: new Date(2017, 0, 1),
-                        color: 'cyan'
-                    },
-                    {
-                        x: new Date(2017, 0, 2),
-                        color: 'magenta'
-                    },
-                    {
-                        x: new Date(2018, 0, 1),
-                        color: 'magenta'
-                    },
-                    {
-                        x: new Date(2018, 4, 1),
-                        color: 'white'
-                    }
-                ]} />
-        </defs>
-        <Line
-            data={aapl}
-            x="Date"
-            y="Close"
-            stroke="url(#rdbu-gradient)" />
-        <Line
-            data={aapl}
-            x="Date"
-            y={(d) => d.Close * 1.2}
-            canvas
-            stroke="url(#rdbu-gradient)" />
-        <Line
-            data={aapl}
-            x="Date"
-            y={(d) => d.Close * 2}
-            stroke="url(#gradient2)" />
-        <Line
-            data={aapl}
-            x="Date"
-            y={(d) => d.Close * 2.2}
-            canvas
-            stroke="url(#gradient2)" />
-    {/snippet}
+<Plot height={250} y={{ grid: true }}>
+    <defs>
+        <LinearGradientY
+            id="gradient-y"
+            stops={[
+                { y: 70, color: 'var(--svp-red)' },
+                { y: 50, color: 'var(--svp-blue)' }
+            ]} />
+    </defs>
+    <Line
+        data={sftemp}
+        x="date"
+        y="high"
+        stroke="url(#gradient-y)" />
+</Plot>
+```
+
+```svelte
+<Plot>
+    <defs>
+        <LinearGradientY
+            id="temp-gradient"
+            stops={[
+                { y: 70, color: 'red' },
+                { y: 50, color: 'blue' }
+            ]} />
+    </defs>
+    <Line
+        data={sftemp}
+        x="date"
+        y="high"
+        stroke="url(#temp-gradient)" />
 </Plot>
 ```

--- a/src/routes/marks/line/+page.ts
+++ b/src/routes/marks/line/+page.ts
@@ -17,7 +17,8 @@ export const load: PageLoad = async ({ fetch }) => {
                     'stateage',
                     'tdf',
                     'rightwing',
-                    'stocks'
+                    'stocks',
+                    'sftemp'
                 ],
                 fetch
             ))


### PR DESCRIPTION
While SveltePlot allows you to use any SVG gradients, you can also make use of the **LinearGradientX** and **LinearGradientY** helpers, which allow mapping data to gradient stops.

https://deploy-preview-42--svelteplot.netlify.app/features/gradients