### PR TITLE
Accept `DataRow` if the input gets `recordized()`

### DIFF
--- a/src/lib/marks/AreaX.svelte
+++ b/src/lib/marks/AreaX.svelte
@@ -3,10 +3,10 @@
     import { renameChannels } from '$lib/transforms/rename.js';
     import { stackX } from '$lib/transforms/stack.js';
     import { recordizeX } from '$lib/transforms/recordize.js';
-    import type { DataRecord, BaseMarkProps, ChannelAccessor } from '../types.js';
+    import type { DataRow, BaseMarkProps, ChannelAccessor } from '../types.js';
 
     type AreaXProps = BaseMarkProps & {
-        data: DataRecord[];
+        data: DataRow[];
         x?: ChannelAccessor;
         x1?: ChannelAccessor;
         x2?: ChannelAccessor;

--- a/src/lib/marks/AreaY.svelte
+++ b/src/lib/marks/AreaY.svelte
@@ -3,13 +3,13 @@
     import { renameChannels } from '$lib/transforms/rename.js';
     import { stackY } from '$lib/transforms/stack.js';
     import { recordizeY } from '$lib/transforms/recordize.js';
-    import type { DataRecord, BaseMarkProps, ChannelAccessor } from '../types.js';
+    import type { DataRow, BaseMarkProps, ChannelAccessor } from '../types.js';
 
     /**
      * AreaY mark foo
      */
     type AreaYProps = BaseMarkProps & {
-        data: DataRecord[];
+        data: DataRow[];
         x?: ChannelAccessor;
         y1?: ChannelAccessor;
         y2?: ChannelAccessor;

--- a/src/lib/marks/Cell.svelte
+++ b/src/lib/marks/Cell.svelte
@@ -9,7 +9,7 @@
     import { resolveChannel } from '../helpers/resolve.js';
     import type {
         PlotContext,
-        DataRecord,
+        DataRow,
         BaseMarkProps,
         BaseRectMarkProps,
         ChannelAccessor
@@ -18,7 +18,7 @@
     import RectPath from './helpers/RectPath.svelte';
 
     type CellProps = BaseMarkProps & {
-        data: DataRecord[];
+        data: DataRow[];
         x?: ChannelAccessor;
         y?: ChannelAccessor;
         borderRadius?:

--- a/src/lib/marks/Geo.svelte
+++ b/src/lib/marks/Geo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { getContext } from 'svelte';
     import type {
-        DataRecord,
+        DataRow,
         PlotContext,
         BaseMarkProps,
         FacetContext,
@@ -22,7 +22,7 @@
     const plot = $derived(getPlotState());
 
     type GeoMarkProps = {
-        data: DataRecord[];
+        data: DataRow[];
         geoType?: 'sphere' | 'graticule';
         dragRotate: boolean;
         canvas: boolean;

--- a/src/lib/marks/Line.svelte
+++ b/src/lib/marks/Line.svelte
@@ -6,7 +6,7 @@
     import type {
         CurveName,
         PlotContext,
-        DataRecord,
+        DataRow,
         BaseMarkProps,
         ConstantAccessor,
         ChannelAccessor,
@@ -15,7 +15,7 @@
     } from '../types.js';
 
     export type BaseLineMarkProps = {
-        data: DataRecord[];
+        data: DataRow[];
         z?: ChannelAccessor;
         stroke?: ChannelAccessor;
         outlineStroke?: string;

--- a/src/lib/marks/RectX.svelte
+++ b/src/lib/marks/RectX.svelte
@@ -2,7 +2,7 @@
     import Rect from './Rect.svelte';
     import { intervalY, stackX, recordizeX } from '$lib/index.js';
     import type {
-        DataRecord,
+        DataRow,
         BaseMarkProps,
         ChannelAccessor,
         BaseRectMarkProps,
@@ -12,7 +12,7 @@
     import { getContext } from 'svelte';
 
     type RectXMarkProps = BaseMarkProps & {
-        data: DataRecord[];
+        data: DataRow[];
         x?: ChannelAccessor;
         x1?: ChannelAccessor;
         x2?: ChannelAccessor;

--- a/src/lib/marks/RectY.svelte
+++ b/src/lib/marks/RectY.svelte
@@ -3,7 +3,7 @@
     import { intervalX, stackY, recordizeY } from '$lib/index.js';
     import type { StackOptions } from '$lib/transforms/stack.js';
     import type {
-        DataRecord,
+        DataRow,
         BaseMarkProps,
         ChannelAccessor,
         BaseRectMarkProps,
@@ -12,7 +12,7 @@
     import { getContext } from 'svelte';
 
     type RectYMarkProps = BaseMarkProps & {
-        data: DataRecord[];
+        data: DataRow[];
         y?: ChannelAccessor;
         y1?: ChannelAccessor;
         y2?: ChannelAccessor;

--- a/src/lib/marks/RuleX.svelte
+++ b/src/lib/marks/RuleX.svelte
@@ -6,14 +6,14 @@
     import { resolveProp, resolveStyles } from '../helpers/resolve.js';
     import type {
         PlotContext,
-        DataRecord,
+        DataRow,
         BaseMarkProps,
         ConstantAccessor,
         ChannelAccessor
     } from '../types.js';
 
     type RuleXMarkProps = BaseMarkProps & {
-        data: DataRecord[];
+        data: DataRow[];
         x?: ChannelAccessor;
         y1?: ChannelAccessor;
         y2?: ChannelAccessor;

--- a/src/lib/marks/RuleY.svelte
+++ b/src/lib/marks/RuleY.svelte
@@ -6,14 +6,14 @@
     import { resolveProp, resolveStyles } from '../helpers/resolve.js';
     import type {
         PlotContext,
-        DataRecord,
+        DataRow,
         BaseMarkProps,
         ConstantAccessor,
         ChannelAccessor
     } from '../types.js';
 
     type RuleYMarkProps = BaseMarkProps & {
-        data: DataRecord[];
+        data: DataRow[];
         y?: ChannelAccessor;
         x1?: ChannelAccessor;
         x2?: ChannelAccessor;


### PR DESCRIPTION
This pull request addresses https://github.com/svelteplot/svelteplot/issues/41 partially.

If the input gets `recordized()`, I guess it's intended to accept `DataRow` instead of `DataRecord`. In other cases, I'm yet to figure out what's the things are supposed to be.