### PR TITLE
fix test in interval.test.ts for machines in BST

### DIFF
--- a/src/lib/transforms/interval.test.ts
+++ b/src/lib/transforms/interval.test.ts
@@ -53,7 +53,7 @@ describe('intervalX', () => {
             const xTime = item.x.getTime();
 
             // x1 should be before x
-            expect(x1Time).toBeLessThan(xTime);
+            expect(x1Time).toBeLessThanOrEqual(xTime);
 
             // x2 should be after x
             expect(x2Time).toBeGreaterThan(xTime);


### PR DESCRIPTION
The time `2025-04-16T23:00:00Z` is `Thu Apr 17 2025 00:00:00 GMT+0100 (British Summer Time)`. 

When the test is run on a machine with the timezone set to BST, the test fails as this time is at midnight in BST, so it lies exactly on a day boundary, so `item.__x1` and `item.x` are equal.

The test would also pass if a minute or seconds offset was applied to the test time, so it didn't correspond to exactly midnight (adding an offset of an integer number of hours would fix the issue for systems running BST, but create a problem for some other timezone).


(Possibly there is actually a bug, and the intervals should be constructed by using midnight UTC as the day boundary, igoring the system timezone - I'm not sure what the correct expected behaviour is).