### PR TITLE
remove spurious period

### DIFF
--- a/src/routes/getting-started/+page.md
+++ b/src/routes/getting-started/+page.md
@@ -46,7 +46,7 @@ You can use SveltePlot inside any platform that supports Svelte 5, such as [Stac
 </Plot>
 ```
 
-[Fork](https://svelte.dev/playground/db6bcdf02859413fa9b3af456f9b9047).
+[Fork](https://svelte.dev/playground/db6bcdf02859413fa9b3af456f9b9047)
 
 ## Use SveltePlot in Svelte 5
 


### PR DESCRIPTION
This period/full stop appears in a separate paragraph under the code snippet:

![image](https://github.com/user-attachments/assets/b200b531-5614-44d1-987d-453b6a957b4a)
