### PR TITLE
fix infinite loop due to comparing dates incorrectly (fix #55)

### DIFF
--- a/src/lib/Mark.svelte
+++ b/src/lib/Mark.svelte
@@ -174,7 +174,9 @@
                 ScaledChannelName,
                 ScaleName
             ][]) {
-                if (array1[i][channel] !== array2[i][channel]) return true;
+                if (!isEqual(array1[i][channel], array2[i][channel])) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
If the data included dates, then the `array1[i][channel] !== array2[i][channel]` check would fail due to `prevResolvedData` and `resolvedData` containing the same value in different Date objects. This led to an infinite effect loop.

This broke one of the examples of applying an Interval transform to dates (https://github.com/svelteplot/svelteplot/issues/55).