### PR TITLE
Align swatches and labels in ColorLegend

### DIFF
--- a/src/lib/marks/ColorLegend.svelte
+++ b/src/lib/marks/ColorLegend.svelte
@@ -163,7 +163,8 @@
     .item,
     .item-label,
     .swatch {
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
     }
     .item-label {
         vertical-align: super;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/f9c782f0-04a5-4b36-907a-9ee76dbdc38b)


After:

![image](https://github.com/user-attachments/assets/ad830346-a09f-45bd-a553-89c94df48381)
