### PR TITLE
feat: pass scales and options to overlay snippet

### DIFF
--- a/src/lib/core/Plot.svelte
+++ b/src/lib/core/Plot.svelte
@@ -519,7 +519,20 @@
                 {/if}
             </FacetGrid>
         </svg>
-        {#if overlay}<div class="plot-overlay">{@render overlay?.()}</div>{/if}
+        {#if overlay}<div class="plot-overlay">
+                {@render overlay?.({
+                    width,
+                    height,
+                    options: plotOptions,
+                    scales: plotState.scales,
+                    mapXY,
+                    hasProjection,
+                    hasExplicitAxisX,
+                    hasExplicitAxisY,
+                    hasExplicitGridX,
+                    hasExplicitGridY
+                })}
+            </div>{/if}
     </div>
     {#if footer}
         <figcaption class="plot-footer">

--- a/src/lib/types/plot.ts
+++ b/src/lib/types/plot.ts
@@ -466,7 +466,7 @@ export type PlotOptions = {
      * The overlay snippet is useful for adding a layer of custom HTML markup
      * in front of the SVG body of your plot, e.g. for HTML tooltips.
      */
-    overlay: Snippet;
+    overlay: Snippet<[{ width: number; height: number; options: PlotOptions; scales: PlotScales }]>;
     facetAxes: Snippet;
     /**
      * if you set testid, the plot container will get a data-testid attribute which


### PR DESCRIPTION
This pull request enhances the functionality of the overlay snippet by passing additional contextual data.

### Enhancements to overlay functionality:

* **Updated overlay rendering in `Plot.svelte`:** The overlay snippet now receives additional parameters, including plot dimensions (`width`, `height`), options (`plotOptions`), scales, and flags indicating explicit axes and grid presence. This enables more dynamic and context-aware overlays.
* **Modified `PlotOptions` type in `plot.ts`:** The `overlay` property type was updated to include a structured snippet that accepts an array with detailed plot state information, enhancing type safety and usability.