### PR TITLE
Fix axis titles getting cut off

### DIFF
--- a/src/lib/marks/AxisX.svelte
+++ b/src/lib/marks/AxisX.svelte
@@ -209,7 +209,9 @@
             )}
             x={plot.options.marginLeft +
                 plot.plotWidth * (titleAlign === 'right' ? 1 : titleAlign === 'center' ? 0.5 : 0)}
-            y={anchor === 'top' ? 13 : plot.height - 13}
+            y={anchor === 'top'
+                ? (options.titleFontSize || 11) + 5
+                : plot.height - (options.titleFontSize || 11) - 5}
             class="axis-x-title"
             dominant-baseline={anchor === 'top' ? 'auto' : 'hanging'}>{useTitle}</text>
     {/if}


### PR DESCRIPTION
Sometimes axis titles with descenders (like 'g', 'y', 'p') were being clipped at the bottom of the chart. Changed the positioning to use the actual font size instead of a hardcoded 13px offset.