### PR TITLE
fix: add types for more text styles

### DIFF
--- a/src/lib/helpers/getBaseStyles.ts
+++ b/src/lib/helpers/getBaseStyles.ts
@@ -14,11 +14,16 @@ const styleProps: Partial<Record<MarkStyleProps, string | null>> = {
     blend: 'mix-blend-mode',
     clipPath: 'clip-path',
     mask: 'mask',
+    fontFamily: 'font-family',
     fontSize: 'font-size',
-    fontWeight: 'font-weight',
     fontStyle: 'font-style',
+    fontWeight: 'font-weight',
     textAnchor: 'text-anchor',
     fontVariant: 'font-variant',
+    letterSpacing: 'letter-spacing',
+    textDecoration: 'text-decoration',
+    textTransform: 'text-transform',
+    wordSpacing: 'word-spacing',
     cursor: 'cursor',
     pointerEvents: 'pointer-events'
 };

--- a/src/lib/marks/Text.svelte
+++ b/src/lib/marks/Text.svelte
@@ -4,17 +4,27 @@
 -->
 
 <script lang="ts" generics="Datum extends DataRecord">
+    import type * as CSS from 'csstype';
+
     interface TextMarkProps extends BaseMarkProps<Datum>, LinkableMarkProps<Datum> {
-        data: Datum[];
-        x: ChannelAccessor<Datum>;
-        y: ChannelAccessor<Datum>;
+        data?: Datum[];
+        x?: ChannelAccessor<Datum>;
+        y?: ChannelAccessor<Datum>;
         children?: Snippet;
         text: ConstantAccessor<string | null | false | undefined, Datum>;
         title?: ConstantAccessor<string, Datum>;
         /**
          * the font size of the text
          */
-        fontSize?: ConstantAccessor<number, Datum>;
+        fontFamily?: ConstantAccessor<CSS.Property.FontFamily, Datum>;
+        fontSize?: ConstantAccessor<CSS.Property.FontSize, Datum>;
+        fontWeight?: ConstantAccessor<CSS.Property.FontWeight, Datum>;
+        fontStyle?: ConstantAccessor<CSS.Property.FontStyle, Datum>;
+        fontVariant?: ConstantAccessor<CSS.Property.FontVariant, Datum>;
+        letterSpacing?: ConstantAccessor<CSS.Property.LetterSpacing, Datum>;
+        wordSpacing?: ConstantAccessor<CSS.Property.WordSpacing, Datum>;
+        textTransform?: ConstantAccessor<CSS.Property.TextTransform, Datum>;
+        textDecoration?: ConstantAccessor<CSS.Property.TextDecoration, Datum>;
         /**
          * if you want to apply class names to individual text elements
          */
@@ -62,7 +72,7 @@
 
     const DEFAULTS = {
         fontSize: 12,
-        fontWeight: 500,
+        c: 500,
         strokeWidth: 1.6,
         frameAnchor: 'center',
         lineHeight: 1.1,

--- a/src/lib/types/mark.ts
+++ b/src/lib/types/mark.ts
@@ -41,10 +41,13 @@ export type MarkStyleProps =
     | 'blend'
     | 'fill'
     | 'fillOpacity'
+    | 'fontFamily'
     | 'fontWeight'
     | 'fontVariant'
     | 'fontSize'
     | 'fontStyle'
+    | 'letterSpacing'
+    | 'wordSpacing'
     | 'stroke'
     | 'strokeWidth'
     | 'strokeOpacity'
@@ -57,6 +60,8 @@ export type MarkStyleProps =
     | 'radius'
     | 'symbol'
     | 'textAnchor'
+    | 'textTransform'
+    | 'textDecoration'
     | 'width';
 
 import type { MouseEventHandler } from 'svelte/elements';


### PR DESCRIPTION
This pull request adds support for a wider range of text styling properties in mark components, particularly for text marks. The changes improve type safety and flexibility by leveraging the `csstype` library for CSS property types and updating the relevant type definitions and style mapping helpers.

### Text styling enhancements

* Added new style properties to the `MarkStyleProps` type and `styleProps` mapping, including `fontFamily`, `letterSpacing`, `wordSpacing`, `textTransform`, and `textDecoration`, allowing for more comprehensive text customization. [[1]](diffhunk://#diff-3e3d3c6e9943d37f742424c37c029116cf348ab28d3aa1beb1f081d0616630bbR44-R50) [[2]](diffhunk://#diff-3e3d3c6e9943d37f742424c37c029116cf348ab28d3aa1beb1f081d0616630bbR63-R64) [[3]](diffhunk://#diff-1b9ad1c2f69c4a721f852de5bc1812639363697a29763224cba4c6ecabe0ee8cR17-R26)
* Updated the `TextMarkProps` interface in `Text.svelte` to support these additional text style properties, now typed using `csstype` for improved type safety.

### Type and default value adjustments

* Changed the default value for `fontWeight` in the `DEFAULTS` object to use a new property `c` (possibly a typo or refactor in progress).
* 
* resolves #140