### PR TITLE
fix: treat infinite values as invalid

### DIFF
--- a/src/lib/helpers/index.test.ts
+++ b/src/lib/helpers/index.test.ts
@@ -1,4 +1,4 @@
-import { coalesce, isObject, omit } from './index.js';
+import { coalesce, isObject, isValid, omit } from './index.js';
 import { describe, it, expect } from 'vitest';
 
 describe('coalesce', () => {
@@ -30,6 +30,19 @@ describe('isObject', () => {
         expect(isObject(123)).toBe(false);
         expect(isObject('string')).toBe(false);
         expect(isObject(true)).toBe(false);
+    });
+});
+
+describe('isValid', () => {
+    it('should return true if the input is an object', () => {
+        expect(isValid(123)).toBe(true);
+        expect(isValid('string')).toBe(true);
+        expect(isValid(new Date())).toBe(true);
+        expect(isValid(null)).toBe(false);
+        expect(isValid(undefined)).toBe(false);
+        expect(isValid(NaN)).toBe(false);
+        expect(isValid(Infinity)).toBe(false);
+        expect(isValid(-Infinity)).toBe(false);
     });
 });
 

--- a/src/lib/helpers/index.ts
+++ b/src/lib/helpers/index.ts
@@ -32,7 +32,12 @@ export function isSnippet(value: unknown): value is Snippet {
 }
 
 export function isValid(value: RawValue | undefined): value is number | Date | string {
-    return value !== null && value !== undefined && !Number.isNaN(value);
+    return (
+        value !== null &&
+        value !== undefined &&
+        !Number.isNaN(value) &&
+        (typeof value !== 'number' || Number.isFinite(value))
+    );
 }
 
 export function maybeData(data: DataRecord[]): DataRecord[] {

--- a/src/lib/helpers/isValid.ts
+++ b/src/lib/helpers/isValid.ts
@@ -1,6 +1,0 @@
-/**
- * @deprecated import from helpers/index.ts instead!
- * @param value
- * @returns
- */
-export { isValid } from './index.js';

--- a/src/lib/helpers/resolve.ts
+++ b/src/lib/helpers/resolve.ts
@@ -2,7 +2,7 @@ import { CHANNEL_SCALE } from '$lib/constants.js';
 import isDataRecord from '$lib/helpers/isDataRecord.js';
 import isRawValue from '$lib/helpers/isRawValue.js';
 import type { MarkStyleProps, PlotState, ScaledDataRecord } from '$lib/types/index.js';
-import { isValid } from './isValid.js';
+import { isValid } from './index.js';
 
 import type {
     ScaleName,

--- a/src/lib/marks/Cell.svelte
+++ b/src/lib/marks/Cell.svelte
@@ -26,7 +26,7 @@
     import { recordizeY, sort } from '$lib/index.js';
     import { resolveChannel } from '../helpers/resolve.js';
 
-    import { isValid } from '../helpers/isValid.js';
+    import { isValid } from '../helpers/index.js';
     import RectPath from './helpers/RectPath.svelte';
 
     let markProps: CellMarkProps = $props();

--- a/src/lib/marks/Dot.svelte
+++ b/src/lib/marks/Dot.svelte
@@ -32,7 +32,6 @@
     import { recordizeXY } from '$lib/transforms/recordize.js';
     import { addEventHandlers } from './helpers/events.js';
     import Anchor from './helpers/Anchor.svelte';
-    import type { D } from 'vitest/dist/chunks/reporters.d.DL9pg5DB.js';
 
     const DEFAULTS = {
         ...getContext<PlotDefaults>('svelteplot/_defaults').dot

--- a/src/lib/marks/TickX.svelte
+++ b/src/lib/marks/TickX.svelte
@@ -35,7 +35,7 @@
     } from '../types/index.js';
     import { recordizeX } from '$lib/index.js';
     import { projectX, projectY } from '../helpers/scales.js';
-    import { isValid } from '../helpers/isValid.js';
+    import { isValid } from '../helpers/index.js';
     import { testFilter, parseInset } from '$lib/helpers/index.js';
 
     const { getPlotState } = getContext<PlotContext>('svelteplot');

--- a/src/lib/marks/TickY.svelte
+++ b/src/lib/marks/TickY.svelte
@@ -34,7 +34,7 @@
     } from '../types/index.js';
     import { recordizeY } from '$lib/index.js';
     import { projectX, projectY } from '../helpers/scales.js';
-    import { isValid } from '../helpers/isValid.js';
+    import { isValid } from '../helpers/index.js';
     import { testFilter, parseInset } from '$lib/helpers/index.js';
 
     const { getPlotState } = getContext<PlotContext>('svelteplot');


### PR DESCRIPTION
This pull request refactors how the `isValid` helper is imported and used throughout the codebase, consolidating its usage and improving its implementation. The most significant changes include updating the logic of `isValid` to better handle numeric edge cases, removing the deprecated separate export, and updating all imports to use the central helper file. Additionally, new tests were added for the improved `isValid` function.

**Helper function improvements:**

* Enhanced the implementation of `isValid` in `src/lib/helpers/index.ts` to ensure that only finite numbers are considered valid, filtering out `Infinity`, `-Infinity`, and `NaN`.

**Testing and code quality:**

* Added a new test suite for `isValid` in `src/lib/helpers/index.test.ts` to verify its behavior with various input types, including numbers, strings, dates, and edge cases like `null`, `undefined`, and non-finite numbers.

**Codebase simplification and consistency:**

* Removed the deprecated export of `isValid` from `src/lib/helpers/isValid.ts` to enforce importing from the main helpers file.
* Updated all imports of `isValid` in mark and helper files (`Cell.svelte`, `TickX.svelte`, `TickY.svelte`, `resolve.ts`) to reference `src/lib/helpers/index.ts` instead of the deprecated file. [[1]](diffhunk://#diff-595f782ae6c8ba44a0434dba7dcb658f026911fb6060f35eba76b12591e5a833L29-R29) [[2]](diffhunk://#diff-86650edd4388a86c0c3e48c68a3e4205242297e3ec04812a3156cbcc0c708e15L38-R38) [[3]](diffhunk://#diff-c47bfe2b144d1116d00fc552ef02187e3e39007804d1c0074f18a2068720f59bL37-R37) [[4]](diffhunk://#diff-4a7d533d8f6b2d3625bf724d7697825bcb5f53f227359209d33bd4aeb2370df9L5-R5)

These changes improve code maintainability and ensure consistent validation logic across the project.

Resolves #118 