### PR TITLE
fix: don't overwrite dx in y channel

### DIFF
--- a/src/lib/Mark.svelte
+++ b/src/lib/Mark.svelte
@@ -270,9 +270,9 @@
 
                     // apply dx/dy transform
                     out[channel] =
-                        scale === 'x' && Number.isFinite(scaled) ? (scaled as number) + dx : scaled;
-                    out[channel] =
-                        scale === 'y' && Number.isFinite(scaled) ? (scaled as number) + dy : scaled;
+                        Number.isFinite(scaled) && (scale === 'x' || scale === 'y')
+                            ? scaled + (scale === 'x' ? dx : dy)
+                            : scaled;
                 } else if (defaults[channel]) {
                     out[channel] = defaults[channel];
                 }

--- a/src/tests/dot.test.ts
+++ b/src/tests/dot.test.ts
@@ -81,4 +81,50 @@ describe('Dot mark', () => {
         expect(dots[0].style.fill).toBe('blue');
         expect(dots[1].style.fill).toBe('red');
     });
+
+    it('no dx and dy offsets', () => {
+        const { container } = render(DotTest, {
+            props: {
+                plotArgs: {},
+                dotArgs: {
+                    data: testData,
+                    x: 'x',
+                    y: 'y',
+                    r: 5
+                }
+            }
+        });
+        const dots = container.querySelectorAll('g.dot > path') as NodeListOf<SVGPathElement>;
+        expect(dots.length).toBe(2);
+
+        const positions = Array.from(dots).map(getTranslate);
+        expect(positions).toStrictEqual([
+            [1, 95],
+            [96, 5]
+        ]);
+    });
+
+    it('dx and dy offsets', () => {
+        const { container } = render(DotTest, {
+            props: {
+                plotArgs: {},
+                dotArgs: {
+                    data: testData,
+                    x: 'x',
+                    y: 'y',
+                    r: 5,
+                    dx: 5,
+                    dy: 5
+                }
+            }
+        });
+        const dots = container.querySelectorAll('g.dot > path') as NodeListOf<SVGPathElement>;
+        expect(dots.length).toBe(2);
+
+        const positions = Array.from(dots).map(getTranslate);
+        expect(positions).toStrictEqual([
+            [6, 100],
+            [101, 10]
+        ]);
+    });
 });


### PR DESCRIPTION
This pull request refines how positional offsets (`dx` and `dy`) are applied to marks in the plot rendering logic, ensuring that both x and y offsets are handled correctly and consistently. It also adds new tests to verify the correct behavior of these offsets for dot marks.

Rendering logic improvements:

* Updated the offset application in `src/lib/Mark.svelte` so that both `dx` and `dy` are conditionally applied based on the scale (`x` or `y`), simplifying and correcting the logic for mark positioning.

Testing enhancements:

* Added tests in `src/tests/dot.test.ts` to verify dot mark positions both with and without `dx` and `dy` offsets, ensuring the rendering logic works as expected.