### PR TITLE
fix tooltip flickering on firefox (#129)

### DIFF
--- a/src/lib/marks/HTMLTooltip.svelte
+++ b/src/lib/marks/HTMLTooltip.svelte
@@ -27,7 +27,10 @@
     let tooltipY = $state();
 
     function onMouseMove(evt: MouseEvent) {
-        const pt = tree.find(evt.layerX, evt.layerY, 25);
+        const plotRect = plot.body.getBoundingClientRect();
+        let relativeX = evt.clientX - plotRect.left;
+        let relativeY = evt.clientY - plotRect.top;
+        const pt = tree.find(relativeX, relativeY, 25);
         if (pt) {
             tooltipX = resolveChannel('x', pt, { x, y, r });
             tooltipY = resolveChannel('y', pt, { x, y, r });

--- a/src/lib/marks/Pointer.svelte
+++ b/src/lib/marks/Pointer.svelte
@@ -50,7 +50,10 @@
     let selectedData = $state([]);
 
     function onMouseMove(evt: MouseEvent) {
-        updateSelection(evt.layerX, evt.layerY);
+        const plotRect = plot.body.getBoundingClientRect();
+        let relativeX = evt.clientX - plotRect.left;
+        let relativeY = evt.clientY - plotRect.top;
+        updateSelection(relativeX, relativeY);
     }
 
     function onTouchMove(evt: TouchEvent) {


### PR DESCRIPTION
I changed the code for `HTMLTooltip` and `Pointer` to not use the [nonstandard `layerX` and `layerY`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/layerX). Instead, the code now uses `clientX` and `clientY` and calculates the relative position via `plot.body.getBoundingClientRect()`. This fixes #129