### PR TITLE
fix: compute correct dataX/dataY in events

### DIFF
--- a/src/lib/marks/helpers/RectPath.svelte
+++ b/src/lib/marks/helpers/RectPath.svelte
@@ -28,18 +28,12 @@ Helper component for rendering rectangular marks in SVG
 
     import { resolveProp, resolveStyles } from 'svelteplot/helpers/resolve';
     import { roundedRect } from 'svelteplot/helpers/roundedRect';
-    import type {
-        BaseMarkProps,
-        BaseRectMarkProps,
-        BorderRadius,
-        ScaledDataRecord,
-        UsedScales,
-        PlotContext,
-        DataRecord
-    } from '$lib/index.js';
     import { addEventHandlers } from './events.js';
     import { getContext } from 'svelte';
     import Anchor from './Anchor.svelte';
+    import type { BaseMarkProps, BaseRectMarkProps, BorderRadius } from 'svelteplot/types/mark.js';
+    import type { DataRecord, ScaledDataRecord } from 'svelteplot/types/data.js';
+    import type { PlotContext, UsedScales } from 'svelteplot/types/index.js';
 
     let {
         datum,

--- a/src/lib/marks/helpers/events.ts
+++ b/src/lib/marks/helpers/events.ts
@@ -82,20 +82,27 @@ export function addEventHandlers(
     for (const [eventName, eventHandler] of Object.entries(events)) {
         if (eventHandler) {
             const wrappedHandler = (origEvent: Event) => {
-                const { scales } = getPlotState();
-                if (origEvent.layerX !== undefined) {
+                const { scales, body, options } = getPlotState();
+                if (origEvent instanceof MouseEvent || origEvent instanceof PointerEvent) {
+                    let facetEl = origEvent.target as SVGElement;
+                    while (facetEl && !facetEl.classList.contains('facet')) {
+                        facetEl = facetEl.parentElement;
+                    }
+                    const facetRect = (facetEl?.firstChild ?? body).getBoundingClientRect();
+                    const relativeX =
+                        origEvent.clientX - facetRect.left + (options.marginLeft ?? 0);
+                    const relativeY = origEvent.clientY - facetRect.top + (options.marginTop ?? 0);
+
                     if (scales.projection) {
-                        const [x, y] = scales.projection.invert([
-                            origEvent.layerX,
-                            origEvent.layerY
-                        ]);
+                        const [x, y] = scales.projection.invert([relativeX, relativeY]);
                         origEvent.dataX = x;
                         origEvent.dataY = y;
                     } else {
-                        origEvent.dataX = invertScale(scales.x, origEvent.layerX);
-                        origEvent.dataY = invertScale(scales.y, origEvent.layerY);
+                        origEvent.dataX = invertScale(scales.x, relativeX);
+                        origEvent.dataY = invertScale(scales.y, relativeY);
                     }
                 }
+
                 eventHandler(
                     origEvent,
                     datum.hasOwnProperty(RAW_VALUE) ? datum[RAW_VALUE] : datum,
@@ -121,10 +128,13 @@ export function addEventHandlers(
 
 function invertScale(scale: PlotScale, position: number) {
     if (scale.type === 'band') {
-        // invert band scale since scaleBand doesn't have an invert function
+        const range = scale.fn.range();
+        const domain = scale.fn.domain();
         const eachBand = scale.fn.step();
-        const index = Math.floor(position / eachBand);
-        return scale.fn.domain()[index];
+        const extent = range[1] - range[0];
+        const posInRange = ((position - range[0]) / extent) * Math.abs(extent);
+        const index = Math.floor(posInRange / eachBand);
+        return domain[index];
     }
     return scale.fn.invert ? scale.fn.invert(position) : undefined;
 }


### PR DESCRIPTION
resolves #183 

**Event handling improvements:**

* In `events.ts`, improved the calculation of event coordinates by:
  - Using `clientX`/`clientY` instead of `layerX`/`layerY` for more accurate positioning.
  - Correctly finding the facet container and adjusting for plot margins.
  - Ensuring compatibility with faceted plots and different event types.

**Scale inversion logic:**

* Enhanced the `invertScale` function for band scales to compute the correct domain value based on the event's position within the plot, leading to more accurate data mapping from pointer events.