### PR TITLE
fix: remove font-family from svg body

### DIFF
--- a/src/lib/core/Plot.svelte
+++ b/src/lib/core/Plot.svelte
@@ -499,8 +499,7 @@
             width={fixedWidth || width}
             {height}
             fill="currentColor"
-            viewBox="0 0 {width} {height}"
-            font-family="system-ui, sans-serif">
+            viewBox="0 0 {width} {height}">
             {@render facetAxes?.()}
             <FacetGrid marks={explicitMarks}>
                 {#if children}

--- a/src/tests/plot.test.ts
+++ b/src/tests/plot.test.ts
@@ -26,6 +26,7 @@ describe('Plot component', () => {
         expect(svg).toBeDefined();
         expect(svg?.getAttribute('width')).toBe('100');
         expect(svg?.getAttribute('height')).toBe('100');
+        expect(svg?.getAttribute('font-family')).toBe(null);
     });
 
     it('plot with title', () => {


### PR DESCRIPTION
This pull request makes a minor update to the `Plot.svelte` component and its associated test. The main change is the removal of the `font-family` attribute from the SVG output, and the test has been updated to verify that this attribute is no longer present.

- Removal of `font-family` attribute from SVG:
  * [`src/lib/core/Plot.svelte`](diffhunk://#diff-fd09193e8ce98e05d0010d7ce7b70476a7e65c82b37e3ff000f900b0d5c504c7L502-R502): The `font-family="system-ui, sans-serif"` attribute was removed from the SVG element.
  * [`src/tests/plot.test.ts`](diffhunk://#diff-907bcb75851672deaa55fa15f1aeddbb62982019d411351c2ff6aa6fbb775e22R29): The test for the Plot component now asserts that the SVG does not have a `font-family` attribute.