### PR TITLE
fix: area with point scales

### DIFF
--- a/src/lib/Mark.svelte
+++ b/src/lib/Mark.svelte
@@ -40,6 +40,7 @@
     import { getUsedScales, projectXY, projectX, projectY } from './helpers/scales.js';
     import { testFilter, isValid } from '$lib/helpers/index.js';
     import { resolveChannel, resolveProp } from './helpers/resolve.js';
+    import { RENAME } from './transforms/rename.js';
 
     let {
         data = [],
@@ -258,11 +259,13 @@
                 if (options?.[channel] != null && out[channel] === undefined) {
                     // resolve value
                     const value = row[channel];
+                    const origChannel = options?.[RENAME]?.[channel] || channel;
+                    console.log('channel', channel, options[RENAME], origChannel, value);
                     const scaled = usedScales[channel]
                         ? scale === 'x'
-                            ? projectX(channel as 'x' | 'x1' | 'x2', plot.scales, value)
+                            ? projectX(origChannel as 'x' | 'x1' | 'x2', plot.scales, value)
                             : scale === 'y'
-                              ? projectY(channel as 'y' | 'y1' | 'y1', plot.scales, value)
+                              ? projectY(origChannel as 'y' | 'y1' | 'y1', plot.scales, value)
                               : scale === 'color' && !isValid(value)
                                 ? plot.options.color.unknown
                                 : plot.scales[scale].fn(value)

--- a/src/lib/helpers/scales.ts
+++ b/src/lib/helpers/scales.ts
@@ -415,7 +415,7 @@ export function inferScaleType(
     if (dataValues.length === 1) return 'point';
     if (dataValues.every(isNumberOrNull)) return name === 'r' ? 'sqrt' : 'linear';
     if (dataValues.every(isDateOrNull)) return 'time';
-    if (dataValues.every(isStringOrNull)) return markTypes.has('arrow') ? 'point' : 'band';
+    if (dataValues.every(isStringOrNull)) return 'point';
     return 'linear';
 }
 

--- a/src/lib/transforms/rename.ts
+++ b/src/lib/transforms/rename.ts
@@ -4,6 +4,9 @@ import type { ScaledChannelName, TransformArg } from '$lib/types/index.js';
 type RenameChannelsOptions = Partial<Record<ScaledChannelName, ScaledChannelName>>;
 type ReplaceChannelsOptions = Partial<Record<ScaledChannelName, ScaledChannelName[]>>;
 
+// using a symbol doesn't work because channels are spread into components
+export const RENAME = '__renamed__';
+
 /**
  * renames a channel without modifying the data
  */
@@ -15,6 +18,9 @@ export function renameChannels<T>(
     for (const [from, to] of Object.entries(options) as [ScaledChannelName, ScaledChannelName][]) {
         if (newChannels[from] !== undefined) {
             newChannels[to] = newChannels[from];
+            // keep track of the renaming
+            newChannels[RENAME] = newChannels[RENAME] || {};
+            newChannels[RENAME][to] = from;
             delete newChannels[from];
         }
     }

--- a/src/routes/examples/area/point-scale.svelte
+++ b/src/routes/examples/area/point-scale.svelte
@@ -1,0 +1,33 @@
+<script module>
+    export const title = 'Area with point scale';
+</script>
+
+<script lang="ts">
+    import { AreaY, Plot, Line } from 'svelteplot';
+    let d = [
+        { key: 'A', amount: -79.0 },
+        { key: 'B', amount: -198.0 },
+        { key: 'C', amount: -88.0 },
+        { key: 'D', amount: 279.0 }
+    ];
+</script>
+
+<Plot grid>
+    <Line
+        class="main"
+        stroke="#23dad9"
+        strokeWidth={3}
+        curve="linear"
+        data={d}
+        x="key"
+        y="amount" />
+    <AreaY
+        class="main"
+        fill="#23dad9"
+        fillOpacity={0.5}
+        strokeWidth={3}
+        curve="linear"
+        data={d}
+        x="key"
+        y="amount" />
+</Plot>


### PR DESCRIPTION
Two fixes:

- don't default to band scales unless mark types bar/cell/tick is used
- map x1 coordinates to center of band if the channel was renamed from x 

Docs:
- add example for area with point scale