### PR TITLE
fix axisY title class

### DIFF
--- a/src/lib/marks/AxisY.svelte
+++ b/src/lib/marks/AxisY.svelte
@@ -197,7 +197,7 @@
             )}
             x={anchor === 'left' ? 0 : plot.width}
             y={5}
-            class="axis-x-title"
+            class="axis-y-title"
             dominant-baseline="hanging">{useTitle}</text>
     {/if}
     {#if showAxis}


### PR DESCRIPTION
resolves #200 

This pull request includes a small change to the `src/lib/marks/AxisY.svelte` file. The class name for the axis title element was corrected from `axis-x-title` to `axis-y-title` to ensure proper styling and semantics.