### PR TITLE
chore: switch to d3-regression TS fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         "d3-path": "^3.1.0",
         "d3-quadtree": "^3.0.1",
         "d3-random": "^3.0.1",
-        "d3-regression": "^1.3.10",
+        "@gka/d3-regression": "^1.3.10-pr48",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
         "d3-shape": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@gka/d3-regression':
+        specifier: ^1.3.10-pr48
+        version: 1.3.10-pr48
       d3-array:
         specifier: ^3.2.4
         version: 3.2.4
@@ -32,9 +35,6 @@ importers:
       d3-random:
         specifier: ^3.0.1
         version: 3.0.1
-      d3-regression:
-        specifier: ^1.3.10
-        version: 1.3.10
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1298,6 +1298,9 @@ packages:
   '@gerrit0/mini-shiki@3.12.2':
     resolution: {integrity: sha512-HKZPmO8OSSAAo20H2B3xgJdxZaLTwtlMwxg0967scnrDlPwe6j5+ULGHyIqwgTbFCn9yv/ff8CmfWZLE9YKBzA==}
 
+  '@gka/d3-regression@1.3.10-pr48':
+    resolution: {integrity: sha512-byMkjXE8AYFsV92AS9QvM9wGKRtxLPBuK1JVHGETGQ2oYql5ZHEDQhP60ovHZdK2xbXYgMqCc6ju0yiIlVrQlQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -2547,9 +2550,6 @@ packages:
   d3-random@3.0.1:
     resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
     engines: {node: '>=12'}
-
-  d3-regression@1.3.10:
-    resolution: {integrity: sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw==}
 
   d3-scale-chromatic@3.1.0:
     resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
@@ -6289,6 +6289,8 @@ snapshots:
       '@shikijs/types': 3.12.2
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@gka/d3-regression@1.3.10-pr48': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -7750,8 +7752,6 @@ snapshots:
   d3-quadtree@3.0.1: {}
 
   d3-random@3.0.1: {}
-
-  d3-regression@1.3.10: {}
 
   d3-scale-chromatic@3.1.0:
     dependencies:

--- a/src/lib/marks/helpers/Regression.svelte
+++ b/src/lib/marks/helpers/Regression.svelte
@@ -43,7 +43,7 @@
         regressionLog,
         regressionPow,
         regressionLoess
-    } from 'd3-regression/dist/d3-regression.esm.js';
+    } from '@gka/d3-regression';
     import { resolveChannel } from '$lib/helpers/resolve.js';
     import { confidenceInterval } from '$lib/helpers/math.js';
     import callWithProps from '$lib/helpers/callWithProps.js';


### PR DESCRIPTION
resolves #18 

This pull request updates the regression library dependency used in the project, switching from the standard `d3-regression` package to a forked TypeScript version, [@gka/d3-regression](https://github.com/svelteplot/d3-regression/pull/1) (thanks to @meded90). This change is reflected across the dependency management files and in the import statements within the codebase.
