### PR TITLE
feat: allow setting margins via defaults

### DIFF
--- a/src/lib/marks/ColorLegend.svelte
+++ b/src/lib/marks/ColorLegend.svelte
@@ -88,7 +88,7 @@
             ).slice(1)}
             <Plot
                 maxWidth="240px"
-                margins={1}
+                margin={1}
                 marginLeft={1}
                 marginRight={1}
                 marginTop={6}
@@ -121,7 +121,7 @@
 
             <Plot
                 maxWidth="240px"
-                margins={1}
+                margin={1}
                 marginLeft={10}
                 marginRight={10}
                 marginTop={6}

--- a/src/lib/marks/helpers/CanvasLayer.svelte
+++ b/src/lib/marks/helpers/CanvasLayer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { getContext } from 'svelte';
-    import type { PlotContext } from '$lib/index.js';
+    import type { PlotContext } from '$lib/types/plot';
     import { devicePixelRatio } from 'svelte/reactivity/window';
     import { MediaQuery } from 'svelte/reactivity';
     import type { Attachment } from 'svelte/attachments';

--- a/src/lib/types/plot.ts
+++ b/src/lib/types/plot.ts
@@ -101,6 +101,13 @@ export type PlotContext = {
 
 type IgnoreDefaults = 'data' | 'facet' | ChannelName | 'title' | 'automatic' | 'children';
 
+export type PlotMargin = {
+    top?: number | 'auto';
+    right?: number | 'auto';
+    bottom?: number | 'auto';
+    left?: number | 'auto';
+};
+
 /**
  * these are the default options for the plot marks that can be set using
  * the 'svelteplot/defaults' context.
@@ -114,6 +121,10 @@ export type PlotDefaults = {
      * default plot inset
      */
     inset: number;
+    /**
+     * default plot margin
+     */
+    margin: 'auto' | number | PlotMargin;
     /**
      * default color scheme
      */
@@ -357,9 +368,11 @@ export type PlotOptions = {
      */
     height: 'auto' | number | ((d: number) => number);
     /**
-     * Convenience option for setting all four margins at once, in px.
+     * If margin is set to "auto" (the default), the plot will automatically
+     * compute appropriate margins based on the presence of axes, labels, and
+     * the overall plot size. You can also set a fixed margin value in px.
      */
-    margin: number | { top?: number; right?: number; bottom?: number; left?: number };
+    margin: PlotMargin | number | 'auto';
     /**
      * Left margin of the plot, in px.
      */

--- a/src/routes/examples/area/area-x.svelte
+++ b/src/routes/examples/area/area-x.svelte
@@ -6,6 +6,8 @@
     import { Plot, AreaX } from 'svelteplot';
     import { page } from '$app/state';
     import type { ExamplesData } from '../types';
+    import { setContext } from 'svelte';
+
     let { aapl } = $derived(page.data.data) as ExamplesData;
 </script>
 

--- a/src/routes/examples/tick/tick-x-quant.svelte
+++ b/src/routes/examples/tick/tick-x-quant.svelte
@@ -8,6 +8,7 @@
 <script lang="ts">
     import { range } from 'd3-array';
     import { Plot, TickX } from 'svelteplot';
+    import type { PlotContext } from 'svelteplot/types/plot';
 </script>
 
 <Plot y={{ type: 'linear' }} marginRight={10} grid>

--- a/src/routes/features/facets/+page.md
+++ b/src/routes/features/facets/+page.md
@@ -36,7 +36,7 @@ Facets are a way to split a plot into multiple panels.
 ```
 
 ```svelte
-<Plot frame grid height={600} inset={10} margins={30}>
+<Plot frame grid height={600} inset={10} margin={30}>
     <Dot
         data={penguins}
         x="culmen_length_mm"
@@ -101,7 +101,7 @@ Apply top-level facet options automatically:
         grid
         height={600}
         inset={10}
-        margins={30}
+        margin={30}
         facet={{ data: penguins, x: 'sex', y: 'island' }}>
         <Frame />
         <Dot

--- a/src/routes/features/plot/+page.md
+++ b/src/routes/features/plot/+page.md
@@ -180,24 +180,25 @@ List of all plot options you can pass via props on the `<Plot />` component:
 - `caption` - a caption to be displayed as `<figcaption>` below the plot
 - `locale` - locale to be used for number and date formatting, e.g. in axis ticks
 
-**Size and margins**
+### Size and margins
 
+- `width` - you can set a fixed width for the plot element, otherwise it will fill 100% of the container width
 - `maxWidth` - you can set the max-width of the plot element to prevent the plot from scaling to the container div width
-- `height`
+- `height` - you can set a fixed height for the plot element, otherwise it will default to 350px or be computed from the plot marks or aspect ratio. Height also accepts a function `(width) => number`
 - `marginTop` - plot margins
 - `marginBottom` - margins
 - `marginLeft` - margins
 - `marginRight` - margins
-- `margin` - shortcut to set all 4 margins to the same value
+- `margin` - shortcut to set all 4 margins to the same value, also accepts objects like `{ top: 10, bottom: 20 }`
 - `inset` - shortcut for setting all insets. To set individual insets, see `x` and `y` scale options.
 
-**Implicit marks**
+### Implicit marks
 
 - `grid` - set this flag to activate implicit grids
 - `axes` - set this flag to activate implicit axes
 - `frame` - set this flag to activate implicit frame
 
-**Scale options**
+### Scale options
 
 - `x` - options for the x scale:
     - `axis`
@@ -256,7 +257,7 @@ List of all plot options you can pass via props on the `<Plot />` component:
 - `symbol` also supports:
     - `legend` - whether to show a symbol legend
 
-**Other plot options**
+### Other plot options
 
 - `locale` - locale used for automatic number and date formatting in axis ticks
 - `aspectRatio` - if set, computes height such that a variation in x of one unit corresponds to the given number of pixels as a variation in y of one unit
@@ -270,7 +271,7 @@ List of all plot options you can pass via props on the `<Plot />` component:
     - `x` - accessor for horizontal facets
     - `y` - accessor for vertical facets
 
-**Snippet options**
+### Snippet options
 
 These can be used to add custom markup to different parts of the plot:
 
@@ -419,3 +420,5 @@ SveltePlot provides a lot of convenience features with the unfortunate side-effe
         y="Adj Close" />
 </Plot>
 ```
+
+You can set default plot options, see [Defaults](/features/defaults) for more information.

--- a/src/routes/marks/axis/+page.md
+++ b/src/routes/marks/axis/+page.md
@@ -506,7 +506,7 @@ You can use two explicit axes to create multiple layers of ticks. The yearly tic
 </script>
 
 <Plot
-    margins={10}
+    margin={10}
     marginBottom={40}
     x={{
         domain: [new Date(2022, 0, 1), new Date(2024, 1, 1)]
@@ -526,7 +526,7 @@ You can use two explicit axes to create multiple layers of ticks. The yearly tic
 
 ```svelte
 <Plot
-    margins={30}
+    margin={30}
     marginBottom={50}
     x={{
         domain: [new Date(2022, 0, 1), new Date(2024, 1, 1)]

--- a/src/routes/marks/cell/+page.md
+++ b/src/routes/marks/cell/+page.md
@@ -255,7 +255,7 @@ But better to use a RectX here:
 
 <Plot
     padding={0}
-    margins={5}
+    margin={5}
     marginTop={40}
     height={70}
     inset={0}

--- a/src/routes/marks/line/+page.md
+++ b/src/routes/marks/line/+page.md
@@ -491,7 +491,7 @@ With a [spherical projection](/features/projections), line segments become [geod
         inset={3}
         width={40}
         height={25}
-        margins={0}
+        margin={0}
         testid="axis-off">
         <Line data={aapl.slice(-60)} x="Date" y="Close" />
     </Plot> inside a text paragraph or table -- often referred
@@ -515,7 +515,7 @@ With a [spherical projection](/features/projections), line segments become [geod
         inset={3}
         width={40}
         height={25}
-        margins={0}>
+        margin={0}>
         <Line data={aapl.slice(-60)} x="Date" y="Close" />
     </Plot> inside a text paragraph or table -- often referred
     to as sparklines.

--- a/src/routes/marks/vector/+page.md
+++ b/src/routes/marks/vector/+page.md
@@ -55,7 +55,7 @@ Here's an example where all arrows point towards the mouse cursor:
 
 <Plot
     inset={10}
-    margins={0}
+    margin={0}
     x={{ axis: false }}
     y={{ axis: false }}
     aspectRatio={1}
@@ -266,7 +266,7 @@ You can use the Vector mark with **custom shapes** by passing an object with a `
 
 <Plot
     inset={10}
-    margins={0}
+    margin={0}
     x={{ axis: false }}
     y={{ axis: false }}
     aspectRatio={1}

--- a/src/routes/tests/facets/+page.md
+++ b/src/routes/tests/facets/+page.md
@@ -51,7 +51,7 @@ Facetted **dot** chart:
         grid
         height={600}
         inset={10}
-        margins={30}
+        margin={30}
         marginTop={35}
         marginBottom={40}
         marginRight={70}>
@@ -255,7 +255,7 @@ Facetted **text** chart
         grid
         height={600}
         inset={10}
-        margins={30}
+        margin={30}
         marginTop={35}
         marginBottom={40}
         marginRight={70}>

--- a/src/tests/plot.test.svelte
+++ b/src/tests/plot.test.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
     import { Plot } from '$lib/index.js';
-    import type { ComponentProps } from 'svelte';
+    import { setContext, type ComponentProps } from 'svelte';
+    import type { PlotDefaults } from 'svelteplot/types';
 
-    let args: ComponentProps<typeof Plot> = $props();
+    let {
+        plotArgs,
+        defaults = {}
+    }: { plotArgs: ComponentProps<typeof Plot>; defaults?: Partial<PlotDefaults> } = $props();
+
+    setContext('svelteplot/defaults', defaults);
 </script>
 
-<Plot {...args} />
+<Plot {...plotArgs} />

--- a/src/tests/plot.test.ts
+++ b/src/tests/plot.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, test } from 'vitest';
 import { render } from '@testing-library/svelte';
 import PlotTest from './plot.test.svelte';
 import ResizeObserver from 'resize-observer-polyfill';
@@ -9,8 +9,10 @@ describe('Plot component', () => {
     it('empty plot', () => {
         const { container } = render(PlotTest, {
             props: {
-                width: 100,
-                height: 100
+                plotArgs: {
+                    width: 100,
+                    height: 100
+                }
             }
         });
 
@@ -32,7 +34,9 @@ describe('Plot component', () => {
     it('plot with title', () => {
         const { container } = render(PlotTest, {
             props: {
-                title: 'Plot title'
+                plotArgs: {
+                    title: 'Plot title'
+                }
             }
         });
         expect(container.querySelectorAll('.plot-header')).toHaveLength(1);
@@ -46,7 +50,9 @@ describe('Plot component', () => {
     it('plot with subtitle', () => {
         const { container } = render(PlotTest, {
             props: {
-                subtitle: 'Plot subtitle'
+                plotArgs: {
+                    subtitle: 'Plot subtitle'
+                }
             }
         });
         expect(container.querySelectorAll('.plot-header')).toHaveLength(1);
@@ -57,7 +63,9 @@ describe('Plot component', () => {
     it('plot with caption', () => {
         const { container } = render(PlotTest, {
             props: {
-                caption: 'Plot caption'
+                plotArgs: {
+                    caption: 'Plot caption'
+                }
             }
         });
         expect(container.querySelectorAll('.plot-footer')).toHaveLength(1);
@@ -67,9 +75,11 @@ describe('Plot component', () => {
     it('plot with title, subtitle and caption', () => {
         const { container } = render(PlotTest, {
             props: {
-                title: 'Main title',
-                subtitle: 'Subtitle text',
-                caption: 'Caption text'
+                plotArgs: {
+                    title: 'Main title',
+                    subtitle: 'Subtitle text',
+                    caption: 'Caption text'
+                }
             }
         });
         expect(container.querySelectorAll('.plot-header')).toHaveLength(1);
@@ -82,8 +92,10 @@ describe('Plot component', () => {
     it('plot with width and height', () => {
         const { container } = render(PlotTest, {
             props: {
-                width: 300,
-                height: 200
+                plotArgs: {
+                    width: 300,
+                    height: 200
+                }
             }
         });
 
@@ -96,9 +108,11 @@ describe('Plot component', () => {
     it('margin settings are applied', () => {
         const { container } = render(PlotTest, {
             props: {
-                width: 100,
-                height: 100,
-                margin: { top: 20, right: 20, bottom: 20, left: 20 }
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    margin: { top: 20, right: 20, bottom: 20, left: 20 }
+                }
             }
         });
 
@@ -116,11 +130,13 @@ describe('Plot component', () => {
     it('scale configuration', () => {
         const { container } = render(PlotTest, {
             props: {
-                width: 100,
-                height: 100,
-                x: { type: 'linear' },
-                y: { type: 'linear' },
-                color: { type: 'ordinal' }
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    x: { type: 'linear' },
+                    y: { type: 'linear' },
+                    color: { type: 'ordinal' }
+                }
             }
         });
 
@@ -133,8 +149,10 @@ describe('Plot component', () => {
     it('plot size', () => {
         const { container } = render(PlotTest, {
             props: {
-                width: 100,
-                height: 150
+                plotArgs: {
+                    width: 100,
+                    height: 150
+                }
             }
         });
 
@@ -146,16 +164,260 @@ describe('Plot component', () => {
         expect(svg?.getAttribute('width')).toBe('100');
         expect(svg?.getAttribute('height')).toBe('150');
     });
+
+    it('initial margins', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    frame: true
+                }
+            }
+        });
+
+        // Check for the presence of the background element
+        // Here we're checking that the plot renders with a background property
+        const svg = container.querySelector('svg');
+
+        expect(svg).not.toBeNull();
+        expect(svg?.getAttribute('width')).toBe('100');
+        expect(svg?.getAttribute('height')).toBe('100');
+
+        const rect = container.querySelector('svg rect.frame');
+        expect(rect).not.toBeNull();
+        expect(rect?.getAttribute('transform')).toBe('translate(1,5)');
+        expect(parseInt(rect?.getAttribute('width') as string)).toBe(95);
+        expect(parseInt(rect?.getAttribute('height') as string)).toBe(90);
+    });
+
+    it('plot margins', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    margin: 10,
+                    width: 100,
+                    height: 100,
+                    frame: true
+                }
+            }
+        });
+
+        // Check for the presence of the background element
+        // Here we're checking that the plot renders with a background property
+        const svg = container.querySelector('svg');
+
+        expect(svg).not.toBeNull();
+        expect(svg?.getAttribute('width')).toBe('100');
+        expect(svg?.getAttribute('height')).toBe('100');
+
+        const rect = container.querySelector('svg rect.frame');
+        expect(rect).not.toBeNull();
+        expect(rect?.getAttribute('transform')).toBe('translate(10,10)');
+        expect(parseInt(rect?.getAttribute('width') as string)).toBe(80);
+        expect(parseInt(rect?.getAttribute('height') as string)).toBe(80);
+    });
+
+    function testMargins(
+        rect: SVGRectElement,
+        margins: { top: number; left: number; bottom: number; right: number }
+    ) {
+        expect(rect).not.toBeNull();
+        expect(rect?.getAttribute('transform')).toBe(`translate(${margins.left},${margins.top})`);
+        expect(parseInt(rect?.getAttribute('width') as string)).toBe(
+            100 - margins.left - margins.right
+        );
+        expect(parseInt(rect?.getAttribute('height') as string)).toBe(
+            100 - margins.top - margins.bottom
+        );
+    }
+
+    it('plot separate margins', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    margin: { top: 15, left: 5, bottom: 15, right: 20 },
+                    width: 100,
+                    height: 100,
+                    frame: true
+                }
+            }
+        });
+
+        // Check for the presence of the background element
+        // Here we're checking that the plot renders with a background property
+        const svg = container.querySelector('svg');
+
+        expect(svg).not.toBeNull();
+        expect(svg?.getAttribute('width')).toBe('100');
+        expect(svg?.getAttribute('height')).toBe('100');
+
+        testMargins(container.querySelector('svg rect.frame') as SVGRectElement, {
+            top: 15,
+            left: 5,
+            bottom: 15,
+            right: 20
+        });
+    });
+
+    it('plot with directional user-default margins', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    frame: true
+                },
+                defaults: {
+                    margin: { top: 10, left: 12, bottom: 14, right: 16 }
+                }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame');
+        testMargins(rect as SVGRectElement, { top: 10, left: 12, bottom: 14, right: 16 });
+    });
+
+    it('plot with uniform user-default margins', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    frame: true
+                },
+                defaults: {
+                    margin: 20
+                }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame');
+        testMargins(rect as SVGRectElement, { top: 20, left: 20, bottom: 20, right: 20 });
+    });
+
+    it('directional plot margin overrides directional user-default margins', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    margin: { top: 5 },
+                    width: 100,
+                    height: 100,
+                    frame: true
+                },
+                defaults: {
+                    margin: { top: 10, left: 12, bottom: 14, right: 16 }
+                }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame') as SVGRectElement;
+        testMargins(rect, { top: 5, left: 12, bottom: 14, right: 16 });
+    });
+
+    it('directional plot margin overrides uniform user-default margin', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    margin: { top: 5 },
+                    width: 100,
+                    height: 100,
+                    frame: true
+                },
+                defaults: {
+                    margin: 10
+                }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame') as SVGRectElement;
+        testMargins(rect, { top: 5, left: 10, bottom: 10, right: 10 });
+    });
+
+    it('uniform plot margin overrides uniform user-default margin', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    margin: 5,
+                    width: 100,
+                    height: 100,
+                    frame: true
+                },
+                defaults: {
+                    margin: 10
+                }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame') as SVGRectElement;
+        testMargins(rect, { top: 5, left: 5, bottom: 5, right: 5 });
+    });
+
+    it('uniform plot margin overrides directional user-default margin', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    margin: 5,
+                    width: 100,
+                    height: 100,
+                    frame: true
+                },
+                defaults: {
+                    margin: { left: 10 }
+                }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame') as SVGRectElement;
+        testMargins(rect, { top: 5, left: 5, bottom: 5, right: 5 });
+    });
+
+    it('shorthand marginLeft overrides uniform plot margin', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    margin: 5,
+                    marginLeft: 15,
+                    width: 100,
+                    height: 100,
+                    frame: true
+                }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame') as SVGRectElement;
+        testMargins(rect, { top: 5, left: 15, bottom: 5, right: 5 });
+    });
+
+    it('shorthand marginLeft overrides directional plot margin', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                plotArgs: {
+                    margin: { left: 10, right: 20 },
+                    marginLeft: 15,
+                    width: 100,
+                    height: 100,
+                    frame: true
+                },
+                defaults: { margin: 5 }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame') as SVGRectElement;
+        testMargins(rect, { top: 5, left: 15, bottom: 5, right: 20 });
+    });
 });
 
 describe('Implicit axes', () => {
     it('accepts x axis domain configuration', () => {
         const { container } = render(PlotTest, {
             props: {
-                width: 100,
-                height: 100,
-                x: {
-                    domain: [0, 10]
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    x: {
+                        domain: [0, 10]
+                    }
                 }
             }
         });
@@ -173,10 +435,12 @@ describe('Implicit axes', () => {
     it('accepts y axis domain configuration', () => {
         const { container } = render(PlotTest, {
             props: {
-                width: 100,
-                height: 100,
-                y: {
-                    domain: [0, 10]
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    y: {
+                        domain: [0, 10]
+                    }
                 }
             }
         });
@@ -194,15 +458,17 @@ describe('Implicit axes', () => {
     it('accepts axis placement configuration', () => {
         const { container } = render(PlotTest, {
             props: {
-                width: 100,
-                height: 100,
-                x: {
-                    domain: [0, 10],
-                    axis: 'top'
-                },
-                y: {
-                    domain: [0, 10],
-                    axis: 'right'
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    x: {
+                        domain: [0, 10],
+                        axis: 'top'
+                    },
+                    y: {
+                        domain: [0, 10],
+                        axis: 'right'
+                    }
                 }
             }
         });


### PR DESCRIPTION
This pull request refactors how plot margins are handled throughout the codebase, replacing the old `margins` prop with a more flexible `margin` prop that supports numbers, objects, and `'auto'`. It introduces a new `PlotMargin` type, updates the default margin logic, and applies these changes across all relevant components, documentation, and tests to ensure consistency and improved configurability.

This means now you can set margins via plot defaults.