### PR TITLE
fix: remove default styles from HtmlTooltip mark

### DIFF
--- a/src/lib/marks/HTMLTooltip.svelte
+++ b/src/lib/marks/HTMLTooltip.svelte
@@ -88,31 +88,19 @@
 </script>
 
 <div
-    class={['tooltip', { hide: !datum }]}
+    class={['svelteplot-tooltip', { hide: !datum }]}
     style:left="{tooltipX ? facetOffsetX + projectX('x', plot.scales, tooltipX) : 0}px"
     style:top="{tooltipY ? facetOffsetY + projectY('y', plot.scales, tooltipY) : 0}px">
-    <div class="tooltip-body">
-        {@render children({ datum })}
-    </div>
+    {@render children({ datum })}
 </div>
 
 <style>
-    div.tooltip {
-        background: white;
-        background: var(--svelteplot-tooltip-bg);
-        border: 1px solid #ccc;
-        border-color: var(--svelteplot-tooltip-border);
-        font-size: 12px;
-        padding: 1ex 1em;
-        border-radius: 3px;
-        line-height: 1.2;
-        box-shadow:
-            rgba(50, 50, 93, 0.25) 0px 2px 5px -1px,
-            rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+    div.svelteplot-tooltip {
         position: absolute;
         pointer-events: none;
-    }
-    .tooltip.hide {
-        display: none;
+
+        &.hide {
+            display: none;
+        }
     }
 </style>

--- a/src/routes/examples/rect/marimekko-faceted.svelte
+++ b/src/routes/examples/rect/marimekko-faceted.svelte
@@ -51,10 +51,26 @@
     {#snippet overlay()}
         <HTMLTooltip {...stacked} r={5}>
             {#snippet children({ datum })}
-                {datum.market}<br />
-                {datum.segment}<br />
-                {datum.value}
+                <div class="tooltip">
+                    {datum.market}<br />
+                    {datum.segment}<br />
+                    {datum.value}
+                </div>
             {/snippet}
         </HTMLTooltip>
     {/snippet}
 </Plot>
+
+<style>
+    .tooltip {
+        background: var(--svelteplot-tooltip-bg);
+        border-color: var(--svelteplot-tooltip-border);
+        font-size: 12px;
+        padding: 1ex 1em;
+        border-radius: 3px;
+        line-height: 1.2;
+        box-shadow:
+            rgba(50, 50, 93, 0.25) 0px 2px 5px -1px,
+            rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+    }
+</style>

--- a/src/routes/features/interactivity/+page.md
+++ b/src/routes/features/interactivity/+page.md
@@ -63,7 +63,7 @@ The `HTMLTooltip` mark allows you to display HTML content when users hover over 
             x="culmen_length_mm"
             y="culmen_depth_mm">
             {#snippet children({ datum })}
-                <div>
+                <div class="tooltip">
                     <div>Species: {datum.species}</div>
                     <div>Island: {datum.island}</div>
                 </div>
@@ -71,6 +71,62 @@ The `HTMLTooltip` mark allows you to display HTML content when users hover over 
         </HTMLTooltip>
     {/snippet}
 </Plot>
+
+<style>
+    .tooltip {
+        background: white;
+        background: var(--svelteplot-tooltip-bg);
+        border: 1px solid #ccc;
+        border-color: var(--svelteplot-tooltip-border);
+        font-size: 12px;
+        padding: 1ex 1em;
+        border-radius: 3px;
+        line-height: 1.2;
+        box-shadow:
+            rgba(50, 50, 93, 0.25) 0px 2px 5px -1px,
+            rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+    }
+</style>
+```
+
+```svelte
+<Plot grid symbol={{ legend: true }}>
+    <Dot
+        data={penguins}
+        x="culmen_length_mm"
+        y="culmen_depth_mm"
+        stroke="species"
+        symbol="species" />
+    {#snippet overlay()}
+        <HTMLTooltip
+            data={penguins}
+            x="culmen_length_mm"
+            y="culmen_depth_mm">
+            {#snippet children({ datum })}
+                <div class="tooltip">
+                    <div>Species: {datum.species}</div>
+                    <div>Island: {datum.island}</div>
+                </div>
+            {/snippet}
+        </HTMLTooltip>
+    {/snippet}
+</Plot>
+
+<style>
+    .tooltip {
+        background: white;
+        background: var(--svelteplot-tooltip-bg);
+        border: 1px solid #ccc;
+        border-color: var(--svelteplot-tooltip-border);
+        font-size: 12px;
+        padding: 1ex 1em;
+        border-radius: 3px;
+        line-height: 1.2;
+        box-shadow:
+            rgba(50, 50, 93, 0.25) 0px 2px 5px -1px,
+            rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+    }
+</style>
 ```
 
 ## SVG Tooltips


### PR DESCRIPTION
This pull request refactors the tooltip styling and markup for the `HTMLTooltip` component and its usage examples. The main goal is to move presentational styles out of the core component and into example and documentation files, making the tooltip more flexible for customization. The most important changes are grouped below.
