### PR TITLE
fix: ignore non-numeric plot height argument

### DIFF
--- a/src/lib/core/Plot.svelte
+++ b/src/lib/core/Plot.svelte
@@ -30,6 +30,7 @@
     import { computeScales, projectXY } from '../helpers/scales.js';
     import { CHANNEL_SCALE, SCALES } from '../constants.js';
     import { getPlotDefaults, setPlotDefaults } from 'svelteplot/hooks/plotDefaults.js';
+    import { maybeNumber } from 'svelteplot/helpers/index.js';
 
     // automatic margins can be applied by the marks, registered
     // with their respective unique identifier as keys
@@ -214,7 +215,7 @@
     // - for one-dimensional scales using the x scale we set a fixed height
     // - for y band-scales we use the number of items in the y domain
     const height = $derived(
-        plotOptions.height === 'auto'
+        maybeNumber(plotOptions.height) === null || plotOptions.height === 'auto'
             ? Math.round(
                   preScales.projection && preScales.projection.aspectRatio
                       ? ((plotWidth * preScales.projection.aspectRatio) / xFacetCount) *
@@ -242,7 +243,7 @@
               )
             : typeof plotOptions.height === 'function'
               ? plotOptions.height(plotWidth)
-              : plotOptions.height
+              : maybeNumber(plotOptions.height)
     );
 
     const plotHeight = $derived(height - plotOptions.marginTop - plotOptions.marginBottom);

--- a/src/lib/helpers/index.test.ts
+++ b/src/lib/helpers/index.test.ts
@@ -1,4 +1,4 @@
-import { coalesce, isObject, isValid, omit } from './index.js';
+import { coalesce, isObject, isValid, maybeNumber, omit } from './index.js';
 import { describe, it, expect } from 'vitest';
 
 describe('coalesce', () => {
@@ -57,5 +57,35 @@ describe('omit', () => {
     it('should not include keys that are not present in the input object', () => {
         expect(omit(obj, 'a', 'b', 'e')).toEqual({ c: 3, d: 4 });
         expect(omit(obj, 'e', 'f')).toEqual(obj);
+    });
+});
+
+describe('maybeNumber', () => {
+    it('return numbers as-is', () => {
+        expect(maybeNumber(42)).toBe(42);
+        expect(maybeNumber(-3.14)).toBe(-3.14);
+        expect(maybeNumber(0)).toBe(0);
+    });
+
+    it('should convert numeric strings to numbers', () => {
+        expect(maybeNumber('42')).toBe(42);
+        expect(maybeNumber('-3.14')).toBe(-3.14);
+        expect(maybeNumber('0')).toBe(0);
+        expect(maybeNumber('  123  ')).toBe(123);
+        expect(maybeNumber('2.5e3')).toBe(2500);
+    });
+
+    it('should return null for non-numeric strings and other types', () => {
+        expect(maybeNumber('abc')).toBeNull();
+        expect(maybeNumber('123abc')).toBeNull();
+        expect(maybeNumber('200px')).toBeNull();
+        expect(maybeNumber('')).toBeNull();
+        expect(maybeNumber(null)).toBeNull();
+        expect(maybeNumber(undefined)).toBeNull();
+        expect(maybeNumber(NaN)).toBeNull();
+        expect(maybeNumber({})).toBeNull();
+        expect(maybeNumber([])).toBeNull();
+        expect(maybeNumber(true)).toBeNull();
+        expect(maybeNumber(Infinity)).toBeNull();
     });
 });

--- a/src/lib/helpers/index.ts
+++ b/src/lib/helpers/index.ts
@@ -51,8 +51,17 @@ export function isObject<T>(option: object | T): option is object {
     );
 }
 
-export function maybeNumber(value: RawValue | null): number | null {
-    return value != null ? +value : null;
+const NUMERIC = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/;
+
+export function maybeNumber(value: any): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string') {
+        // only accept numeric strings
+        if (NUMERIC.test(value.trim())) {
+            return parseFloat(value);
+        }
+    }
+    return null;
 }
 
 export const constant =


### PR DESCRIPTION
This pull request improves how plot height is determined in the `Plot.svelte` component by introducing stricter handling and conversion of numeric values. The key change is the use of a new `maybeNumber` helper function, which safely parses and validates numbers and numeric strings. Comprehensive tests for `maybeNumber` have also been added to ensure reliability.

resolves #221 