### PR TITLE
fix: implement paddingInner and paddingOuter

### DIFF
--- a/src/lib/helpers/autoScales.ts
+++ b/src/lib/helpers/autoScales.ts
@@ -160,7 +160,32 @@ export function autoScale({
         ...(type === 'band' || type === 'point'
             ? {
                   align: scaleOptions.align,
-                  padding: maybeNumber(coalesce(scaleOptions.padding, plotOptions.padding, 0.15))
+                  ...(type === 'point'
+                      ? {
+                            // point scales don't have paddingInner/Outer, only padding
+                            padding: maybeNumber(
+                                coalesce(scaleOptions.padding, plotOptions.padding, 0.15)
+                            )
+                        }
+                      : {
+                            //   padding: maybeNumber(coalesce(scaleOptions.padding, plotOptions.padding, 0.15)),
+                            paddingInner: maybeNumber(
+                                coalesce(
+                                    scaleOptions.paddingInner,
+                                    scaleOptions.padding,
+                                    plotOptions.padding,
+                                    0.15
+                                )
+                            ),
+                            paddingOuter: maybeNumber(
+                                coalesce(
+                                    scaleOptions.paddingOuter,
+                                    scaleOptions.padding,
+                                    plotOptions.padding,
+                                    0.15
+                                )
+                            )
+                        })
               }
             : {})
     };

--- a/src/routes/features/scales/+page.md
+++ b/src/routes/features/scales/+page.md
@@ -397,17 +397,69 @@ We can also see that the scale is no longer sorted by cylinders, as the domain o
 
 ### Band scale
 
-## Categorical colors
-
-Categorical color scales are useful for mapping categories to colors. The following categorical schemes are included in SveltePlot:
+Band scales are similar to point scales but allocate space for each category. This is useful for extent-based marks like [Bar](/marks/bar) marks. In the following example, the car manufacturers are categorical data so the plot uses a band scale for the x scale.
 
 ```svelte live
 <script>
-    import { Plot, Dot } from 'svelteplot';
+    import { Plot, BarY, groupX, Frame } from 'svelteplot';
+    import { Slider } from '$lib/ui';
     import { page } from '$app/state';
     let { penguins } = $derived(page.data.data);
+    let paddingInner = $state(0.1);
+    let paddingOuter = $state(0.25);
+    let align = $state(0.5);
+
+    const domain = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
 </script>
 
+<Slider
+    label="paddingInner"
+    bind:value={paddingInner}
+    min={0}
+    max={0.9}
+    step={0.01} />
+<Slider
+    label="paddingOuter"
+    bind:value={paddingOuter}
+    min={0}
+    max={0.9}
+    step={0.01} />
+<Slider
+    label="align"
+    bind:value={align}
+    min={0}
+    max={1}
+    step={0.01} />
+
+<Plot
+    x={{
+        type: 'band',
+        grid: true,
+        align,
+        paddingInner,
+        paddingOuter
+    }}
+    marginTop={30}
+    y={{ axis: false }}
+    height={120}>
+    <Frame opacity={0.2} />
+    <BarY
+        data={domain.map((d) => ({
+            category: d,
+            value: 1
+        }))}
+        stroke="currentColor"
+        x="category"
+        y="value" />
+</Plot>
+```
+
+## Categorical colors
+
+Categorical color scales are useful for mapping categories to colors. The following categorical
+schemes are included in SveltePlot:
+
+```svelte --live
 <Plot color={{ legend: true }}>
     <Dot
         data={penguins}


### PR DESCRIPTION
This pull request implements the band scale options paddingInner and paddingOuter that were included in the typings but not respected
