### PR TITLE
fix: text along line

### DIFF
--- a/src/lib/marks/Line.svelte
+++ b/src/lib/marks/Line.svelte
@@ -201,7 +201,7 @@
                                             : args.textStroke
                                               ? 2
                                               : 0,
-                                        fill: args.textFill || args.stroke,
+                                        fill: args.textFill || lineData[0].stroke,
                                         stroke: args.textStroke
                                     },
                                     'fill',

--- a/src/tests/line.test.svelte.ts
+++ b/src/tests/line.test.svelte.ts
@@ -179,6 +179,26 @@ describe('Line mark', () => {
         expect(text?.textContent).toBe('Label');
     });
 
+    it('line with colored text from data', () => {
+        const { container } = render(LineTest, {
+            props: {
+                data: [
+                    { x: 0, y: 0, label: 'Label' },
+                    { x: 1, y: 1, label: 'Label' }
+                ],
+                x: 'x',
+                y: 'y',
+                stroke: 'label',
+                text: (d) => d.label
+            }
+        });
+
+        const text = container.querySelector('g.lines > g > text') as SVGTextElement;
+        expect(text).not.toBeNull();
+        expect(text?.textContent).toBe('Label');
+        expect(text?.style.fill).toBe('#4269d0');
+    });
+
     it('line with text label and custom style', () => {
         const { container } = render(LineTest, {
             props: {


### PR DESCRIPTION
This pull request improves how text labels are rendered and styled in the `Line` mark component, especially when the text and color are derived from the data. It also adds new tests to verify these behaviors.

Enhancements to text label rendering and styling:

* Updated the `fill` property for text labels to use the stroke color from `lineData[0]` if `textFill` is not provided, ensuring consistency when the stroke is data-driven.
* Changed the text label binding to use `lineData[0].datum` instead of `lineData[0]`, allowing the text to be correctly derived from the data object.

