### PR TITLE
Add Svelte Playground link for AreaY example

### DIFF
--- a/src/routes/examples/area/area-y.svelte
+++ b/src/routes/examples/area/area-y.svelte
@@ -2,6 +2,8 @@
     export const title = 'AreaY';
     export const data = { aapl: '/data/aapl.csv' };
     export const sortKey = 3;
+    export const repl =
+        'https://svelte.dev/playground/3a0e5ea3118e48378d9302ce35d992f8?version=latest';
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
Example: https://svelteplot.dev/examples/area/area-y
Playground: https://svelte.dev/playground/3a0e5ea3118e48378d9302ce35d992f8?version=latest