### PR TITLE
fix: provide fallback for --svelteplot-bg CSS var

### DIFF
--- a/src/lib/Mark.svelte
+++ b/src/lib/Mark.svelte
@@ -325,7 +325,7 @@
 
 <style>
     text {
-        stroke: var(--plot-bg);
+        stroke: var(--svp-bg);
         fill: crimson;
         font-size: 11px;
         stroke-width: 3px;

--- a/src/lib/Plot.svelte
+++ b/src/lib/Plot.svelte
@@ -177,17 +177,13 @@
 </svelte:boundary>
 
 <style>
-    :root {
-        --plot-bg: white;
-        --plot-fg: currentColor;
-    }
     .error {
         font-size: 11px;
         stroke-width: 3px;
         font-weight: bold;
     }
     text.error {
-        stroke: var(--plot-bg);
+        stroke: var(--svelteplot-bg, white);
         fill: crimson;
         paint-order: stroke fill;
     }

--- a/src/lib/core/Plot.svelte
+++ b/src/lib/core/Plot.svelte
@@ -578,12 +578,8 @@
 </figure>
 
 <style>
-    :root {
-        --plot-bg: white;
-        --plot-fg: currentColor;
-    }
-
     figure {
+        --svp-bg: var(--svelteplot-bg, white);
         margin: 0;
         padding: 0;
     }

--- a/src/lib/marks/helpers/Marker.svelte
+++ b/src/lib/marks/helpers/Marker.svelte
@@ -74,7 +74,7 @@
     const markerColors = $derived({
         fill: 'none',
         [MARKERS[shape].color]: color,
-        ...(MARKERS[shape].bg ? { [MARKERS[shape].bg as string]: 'var(--svelteplot-bg)' } : {})
+        ...(MARKERS[shape].bg ? { [MARKERS[shape].bg as string]: 'var(--svp-bg)' } : {})
     });
 </script>
 


### PR DESCRIPTION
resolves #117 

This pull request updates how background color variables are handled across several components to improve consistency and flexibility in theming. The main change is the introduction of a new CSS variable `--svp-bg`, which replaces direct usage of `--svelteplot-bg` and the previously defined `--plot-bg`. This change ensures that all components reference the same background color variable, making it easier to maintain and customize the plot's appearance.

**Theming and CSS variable improvements:**

* Introduced the `--svp-bg` CSS variable in `figure` styles within `src/lib/core/Plot.svelte`, set to fallback to `--svelteplot-bg` or white if not defined. Removed redundant `:root` variable definitions.
* Updated background color references in marker helpers to use `--svp-bg` instead of `--svelteplot-bg`, ensuring consistent theming in `src/lib/marks/helpers/Marker.svelte`.
* Changed the stroke color in `src/lib/Mark.svelte` to use `--svp-bg` instead of the deprecated `--plot-bg` variable.
* Updated error text stroke color in `src/lib/Plot.svelte` to use `--svelteplot-bg` (with fallback to white) for better theme support, and removed obsolete root-level variables.