### PR TITLE
Docs: Ported Frame, Grid, and remaining Dot examples to Svelte Playground

### DIFF
--- a/src/routes/examples/dot/jitter-x.svelte
+++ b/src/routes/examples/dot/jitter-x.svelte
@@ -4,6 +4,8 @@
     export const transforms = ['jitter'];
     export const data = { cars: '/data/cars.csv' };
     export const description = `This example demonstrates how to apply <a href="/transforms/jitter">jittering</a> along the x-axis.`;
+    export const repl =
+        'https://svelte.dev/playground/bd80bef3a05f4de593943b6ec85db240?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/dot/jitter-y.svelte
+++ b/src/routes/examples/dot/jitter-y.svelte
@@ -4,6 +4,8 @@
     export const transforms = ['jitter'];
     export const data = { cars: '/data/cars.csv' };
     export const description = `This example demonstrates how to apply <a href="/transforms/jitter">jittering</a> along the y-axis.`;
+    export const repl =
+        'https://svelte.dev/playground/4be18771e9f24d0994c481b9656acc3b?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/dot/jitter.svelte
+++ b/src/routes/examples/dot/jitter.svelte
@@ -4,6 +4,8 @@
     export const transforms = ['jitter'];
     export const data = { cars: '/data/cars.csv' };
     export const description = `This example demonstrates how to apply <a href="/transforms/jitter">jittering</a> along multiple axes.`;
+    export const repl =
+        'https://svelte.dev/playground/fe3b55628a924c7a85e2d6a821ee76dd?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/frame/explicit-frame.svelte
+++ b/src/routes/examples/frame/explicit-frame.svelte
@@ -1,5 +1,7 @@
 <script module>
     export const title = 'Explicit frame';
+    export const repl =
+        'https://svelte.dev/playground/0e2f588180a247daa574bb15fc6a40b9?version=latest';
 </script>
 
 <script>

--- a/src/routes/examples/frame/frame-dx-dy.svelte
+++ b/src/routes/examples/frame/frame-dx-dy.svelte
@@ -1,5 +1,7 @@
 <script module>
     export const title = 'Frame with dx and dy';
+    export const repl =
+        'https://svelte.dev/playground/38c7fe8c22b64892b886841f3892464a?version=latest';
 </script>
 
 <script>

--- a/src/routes/examples/frame/ggplot-style.svelte
+++ b/src/routes/examples/frame/ggplot-style.svelte
@@ -3,6 +3,8 @@
     export const description =
         'A frame with a light gray fill and white grid lines, similar to ggplot2 style.';
     export const data = { aapl: '/data/aapl.csv' };
+    export const repl =
+        'https://svelte.dev/playground/92fc8477b933424e8726c2311207c05d?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/frame/implicit-frame.svelte
+++ b/src/routes/examples/frame/implicit-frame.svelte
@@ -2,6 +2,8 @@
     export const title = 'Implicit frame';
     export const description =
         'A Plot with the frame option creates an implicit frame.';
+    export const repl =
+        'https://svelte.dev/playground/9a0f848d41a7404ea636ffbbe8902831?version=latest';
 </script>
 
 <script>

--- a/src/routes/examples/grid/clipped-gridlines.svelte
+++ b/src/routes/examples/grid/clipped-gridlines.svelte
@@ -3,6 +3,8 @@
     export const description =
         'You can use an area mark as clipping path for grid lines';
     export const data = { aapl: '/data/aapl.csv' };
+    export const repl =
+        'https://svelte.dev/playground/f66c595241304e668c0edafb6b1dea85?version=latest';
 </script>
 
 <script>

--- a/src/routes/examples/grid/gridlines-x2.svelte
+++ b/src/routes/examples/grid/gridlines-x2.svelte
@@ -3,6 +3,8 @@
     export const description =
         'Use x1 and x2 channels to let grid lines stop at a data value';
     export const data = { aapl: '/data/aapl.csv' };
+    export const repl =
+        'https://svelte.dev/playground/50fe3ab6444d4daf9f9a2805a9ff9828?version=latest';
 </script>
 
 <script>

--- a/src/routes/examples/grid/gridlines-y2.svelte
+++ b/src/routes/examples/grid/gridlines-y2.svelte
@@ -3,6 +3,8 @@
     export const description =
         'You can use an area mark as clipping path for grid lines';
     export const data = { aapl: '/data/aapl.csv' };
+    export const repl =
+        'https://svelte.dev/playground/52d1abcbe3e54564a3d619fc92eba498?version=latest';
 </script>
 
 <script>


### PR DESCRIPTION
Ported Frame, Grid, and remaining Dot examples to Svelte Playground.