### PR TITLE
Ported image and line examples to Svelte Playground

### DIFF
--- a/src/routes/examples/image/image-beeswarm.svelte
+++ b/src/routes/examples/image/image-beeswarm.svelte
@@ -5,6 +5,8 @@
     export const data = {
         presidents2: '/data/presidents2.csv'
     };
+    export const repl =
+        'https://svelte.dev/playground/9fb9afe5e2fb4a6da5fa01f546db9a7a?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/apple-stock.svelte
+++ b/src/routes/examples/line/apple-stock.svelte
@@ -3,6 +3,8 @@
     export const description =
         "The classic line chart example you've seen a million times.";
     export const data = { aapl: '/data/aapl.csv' };
+    export const repl =
+        'https://svelte.dev/playground/aed3ceb107644129801fe51cf205b09c?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/comparing-quantiles.svelte
+++ b/src/routes/examples/line/comparing-quantiles.svelte
@@ -7,6 +7,8 @@
         'You can use the <a href="/transforms/map">map transform</a> to compare different distributions against their quantiles. This is sometimes referred to as <a href="https://www.sciencedirect.com/topics/mathematics/quantile-plot">quantile plot</a>.';
     export const transforms = ['map'];
     export const sortKey = 80;
+    export const repl =
+        'https://svelte.dev/playground/8221090246714f59a7752e8ac8285978?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/density.svelte
+++ b/src/routes/examples/line/density.svelte
@@ -6,6 +6,8 @@
     export const description =
         'Density plot of the measurements in the <a href="https://en.wikipedia.org/wiki/Iris_flower_data_set">Iris flower dataset</a>, showing density estimates for each measurement type.';
     export const transforms = ['density'];
+    export const repl =
+        'https://svelte.dev/playground/24c1d53d571b468bae67922bd8e721d7?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/gradient-line.svelte
+++ b/src/routes/examples/line/gradient-line.svelte
@@ -1,6 +1,8 @@
 <script module>
     export const title = 'Gradient line';
     export const data = { aapl: '/data/aapl.csv' };
+    export const repl =
+        'https://svelte.dev/playground/7989004c109a436895de1668c0fee708?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/indexed-stocks.svelte
+++ b/src/routes/examples/line/indexed-stocks.svelte
@@ -7,6 +7,8 @@
     };
     export const sortKey = 10;
     export const transforms = ['normalize'];
+    export const repl =
+        'https://svelte.dev/playground/2cef2e079ab34d429be7fad6ac289635?version=latest';
 </script>
 
 <script>

--- a/src/routes/examples/line/line-grouping.svelte
+++ b/src/routes/examples/line/line-grouping.svelte
@@ -1,6 +1,8 @@
 <script module>
     export const title = 'Line grouping';
     export const data = { aapl: '/data/aapl.csv' };
+    export const repl =
+        'https://svelte.dev/playground/560acc13b1844298a2fce48b9f71ea2e?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/parallel-x.svelte
+++ b/src/routes/examples/line/parallel-x.svelte
@@ -5,6 +5,8 @@
     export const data = { iris: '/data/iris2.csv' };
     export const sortKey = 102;
     export const transforms = ['normalize'];
+    export const repl =
+        'https://svelte.dev/playground/560d60d41f794ee58222d75e3fd132af?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/penguins-cdf.svelte
+++ b/src/routes/examples/line/penguins-cdf.svelte
@@ -4,6 +4,8 @@
     export const description =
         '<a href="https://en.wikipedia.org/wiki/Cumulative_distribution_function">Cumulative distribution</a> of body mass in the Palmer penguins dataset, one curve per species.';
     export const transforms = ['density'];
+    export const repl =
+        'https://svelte.dev/playground/9beba1b1cecf4585bfa65adb760db743?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/running-mean.svelte
+++ b/src/routes/examples/line/running-mean.svelte
@@ -6,6 +6,8 @@
     export const transforms = ['window', 'bin', 'select'];
     export const fullCode = true;
     export const data = { stocks: '/data/stocks.csv' };
+    export const repl =
+        'https://svelte.dev/playground/0f476e86418f4b1a84f25a6b529b04ec?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/shifted-line.svelte
+++ b/src/routes/examples/line/shifted-line.svelte
@@ -4,6 +4,8 @@
         'A line plot with one line shifted by 2 months along the x-axis.';
     export const transforms = ['shift'];
     export const data = { aapl: '/data/aapl.csv' };
+    export const repl =
+        'https://svelte.dev/playground/0bc63640234d49e4b381ad8e739d8979?version=latest';
 </script>
 
 <script lang="ts">

--- a/src/routes/examples/line/tour-de-france.svelte
+++ b/src/routes/examples/line/tour-de-france.svelte
@@ -3,6 +3,8 @@
     export const description =
         'While the x scale of a line chart often represents time, this is not required. For example, we can plot the elevation profile of a Tour de France stage. Based on an example from <a href="https://observablehq.com/@observablehq/plot-tour-de-france-elevation-profile">Observable Plot</a>.';
     export const data = { tdf: '/data/tdf.csv' };
+    export const repl =
+        'https://svelte.dev/playground/591376db8f004262a4369d58a60583b9?version=latest';
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
All image and line examples now have Svelte Playground links.