### PR TITLE
docs: add JSDoc to axis, grid, and tick mark components

### DIFF
--- a/src/lib/marks/AxisX.svelte
+++ b/src/lib/marks/AxisX.svelte
@@ -24,22 +24,35 @@
         BaseMarkProps<Datum>,
         'fillOpacity' | 'paintOrder' | 'title' | 'href' | 'target'
     > {
+        /** custom tick values to display on the axis */
         data?: Datum[];
+        /** whether this axis was automatically added by the Plot component */
         automatic?: boolean;
+        /** the axis title label; set to false or null to hide */
         title?: string | false | null;
+        /** which edge of the plot the axis appears on */
         anchor?: 'top' | 'bottom';
+        /** the interval between ticks, e.g. "day", "month", or a number */
         interval?: string | number;
+        /** controls which facet edge displays this axis */
         facetAnchor?: 'auto' | 'top-empty' | 'bottom-empty' | 'top' | 'bottom';
+        /** horizontal alignment of the axis title */
         labelAnchor?: 'auto' | 'left' | 'center' | 'right';
+        /** the length of tick marks in pixels */
         tickSize?: number;
+        /** font size for tick labels */
         tickFontSize?: ConstantAccessor<number, Datum>;
+        /** font size for the axis title */
         titleFontSize?: number;
+        /** spacing between tick marks and tick labels in pixels */
         tickPadding?: number;
+        /** formatter for tick labels; can be "auto", an Intl format options object, or a custom function */
         tickFormat?:
             | 'auto'
             | Intl.DateTimeFormatOptions
             | Intl.NumberFormatOptions
             | ((d: RawValue, i: number) => string);
+        /** CSS class applied to each tick label */
         tickClass?: ConstantAccessor<string, Datum>;
         /** ticks is a shorthand for defining data, tickCount or interval */
         ticks?: number | string | Datum[];

--- a/src/lib/marks/AxisY.svelte
+++ b/src/lib/marks/AxisY.svelte
@@ -23,24 +23,39 @@
         BaseMarkProps<Datum>,
         'fillOpacity' | 'paintOrder' | 'title' | 'href' | 'target'
     > {
+        /** custom tick values to display on the axis */
         data?: Datum[];
+        /** whether this axis was automatically added by the Plot component */
         automatic?: boolean;
+        /** the axis title label; set to false or null to hide */
         title?: string | false | null;
+        /** which edge of the plot the axis appears on */
         anchor?: 'left' | 'right';
+        /** controls which facet edge displays this axis */
         facetAnchor?: 'auto' | 'left' | 'right' | 'left-empty' | 'right-empty';
+        /** vertical alignment of tick labels relative to the tick position */
         lineAnchor?: 'top' | 'center' | 'bottom';
+        /** the interval between ticks, e.g. "day", "month", or a number */
         interval?: string | number;
+        /** horizontal alignment of the axis title */
         labelAnchor?: 'auto' | 'left' | 'center' | 'right';
+        /** text anchor for tick labels */
         textAnchor?: 'auto' | 'start' | 'middle' | 'end';
+        /** the length of tick marks in pixels */
         tickSize?: number;
+        /** font size for tick labels */
         tickFontSize?: ConstantAccessor<number, Datum>;
+        /** font size for the axis title */
         titleFontSize?: number;
+        /** spacing between tick marks and tick labels in pixels */
         tickPadding?: number;
+        /** formatter for tick labels; can be "auto", an Intl format options object, or a custom function */
         tickFormat?:
             | 'auto'
             | Intl.DateTimeFormatOptions
             | Intl.NumberFormatOptions
             | ((d: RawValue) => string);
+        /** CSS class applied to each tick label */
         tickClass?: ConstantAccessor<string, Datum>;
         /** ticks is a shorthand for defining data, tickCount or interval */
         ticks?: number | string | Datum[];

--- a/src/lib/marks/GridX.svelte
+++ b/src/lib/marks/GridX.svelte
@@ -3,9 +3,13 @@
 -->
 <script lang="ts" generics="Datum = RawValue">
     interface GridXMarkProps extends Omit<BaseMarkProps<Datum>, 'fill' | 'fillOpacity'> {
+        /** custom values at which to draw vertical gridlines */
         data?: Datum[];
+        /** whether these gridlines were automatically added by the Plot component */
         automatic?: boolean;
+        /** the starting vertical position of the gridline */
         y1?: ChannelAccessor<Datum>;
+        /** the ending vertical position of the gridline */
         y2?: ChannelAccessor<Datum>;
     }
     import Mark from '../Mark.svelte';

--- a/src/lib/marks/GridY.svelte
+++ b/src/lib/marks/GridY.svelte
@@ -3,9 +3,13 @@
 -->
 <script lang="ts" generics="Datum = RawValue">
     interface GridYMarkProps extends Omit<BaseMarkProps<Datum>, 'fill' | 'fillOpacity'> {
+        /** custom values at which to draw horizontal gridlines */
         data?: Datum[];
+        /** whether these gridlines were automatically added by the Plot component */
         automatic?: boolean;
+        /** the starting horizontal position of the gridline */
         x1?: ChannelAccessor<Datum>;
+        /** the ending horizontal position of the gridline */
         x2?: ChannelAccessor<Datum>;
     }
     import Mark from '../Mark.svelte';

--- a/src/lib/marks/TickX.svelte
+++ b/src/lib/marks/TickX.svelte
@@ -5,6 +5,7 @@
 
 <script lang="ts" generics="Datum extends DataRow">
     interface TickXMarkProps extends Omit<BaseMarkProps<Datum>, 'fill' | 'fillOpacity'> {
+        /** the input data array; each element becomes one vertical tick */
         data: Datum[];
         /**
          * the horizontal position; bound to the x scale
@@ -20,6 +21,7 @@
          * length of the tick. Defaults to 10 pixel
          */
         tickLength?: ConstantAccessor<number, Datum>;
+        /** if true, renders using Canvas instead of SVG */
         canvas?: boolean;
     }
     import Mark from '../Mark.svelte';

--- a/src/lib/marks/TickY.svelte
+++ b/src/lib/marks/TickY.svelte
@@ -4,14 +4,15 @@
 -->
 <script lang="ts" generics="Datum extends DataRow">
     interface TickYMarkProps extends Omit<BaseMarkProps<Datum>, 'fill' | 'fillOpacity'> {
+        /** the input data array; each element becomes one horizontal tick */
         data: Datum[];
         /**
-         * the vertical position; bound to the x scale
+         * the vertical position; bound to the y scale
          */
         y?: ChannelAccessor<Datum>;
         /**
-         * the horizontal position; bound to the y scale, which must be band. If the y channel
-         * is not specified, the tick will span the full vertical extent of the frame.
+         * the horizontal position; bound to the x scale, which must be band. If the x channel
+         * is not specified, the tick will span the full horizontal extent of the frame.
          */
         x?: ChannelAccessor<Datum>;
         /**
@@ -19,6 +20,7 @@
          * length of the tick. Defaults to 10 pixel
          */
         tickLength?: ConstantAccessor<number, Datum>;
+        /** if true, renders using Canvas instead of SVG */
         canvas?: boolean;
     }
     import Mark from '../Mark.svelte';


### PR DESCRIPTION
## Summary
- Add JSDoc comments to all undocumented props in **AxisX**, **AxisY**, **GridX**, **GridY**, **TickX**, and **TickY** mark components
- Fix incorrect scale references in TickY JSDoc (x/y were swapped)
- Follows the same pattern established in #360 and #361

## Details

| Component | Props documented |
|-----------|-----------------|
| AxisX | 13 props (data, automatic, title, anchor, interval, facetAnchor, labelAnchor, tickSize, tickFontSize, titleFontSize, tickPadding, tickFormat, tickClass) |
| AxisY | 15 props (same as AxisX + lineAnchor, textAnchor) |
| GridX | 4 props (data, automatic, y1, y2) |
| GridY | 4 props (data, automatic, x1, x2) |
| TickX | 2 props (data, canvas) |
| TickY | 2 props (data, canvas) + fixed existing x/y JSDoc |

## Test plan
- [x] `pnpm run lint` passes
- [ ] Verify hovering over component props in editor shows JSDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)