### PR TITLE
docs: add JSDoc to interaction and shape mark components

### DIFF
--- a/src/lib/marks/Brush.svelte
+++ b/src/lib/marks/Brush.svelte
@@ -15,6 +15,7 @@
         | 'strokeLinejoin'
         | 'strokeMiterlimit'
     > {
+        /** the brush state object (bindable); contains x1, x2, y1, y2, and enabled */
         brush: Brush;
         /**
          * limit brushing to x or y dimension
@@ -28,8 +29,11 @@
          * size of the (invisible) drag resize area around the edges of the brush selection
          */
         resizeHandleSize?: number;
+        /** called when the user starts dragging to create or move a brush */
         onbrushstart?: (evt: BrushEvent) => void;
+        /** called when the user finishes dragging the brush */
         onbrushend?: (evt: BrushEvent) => void;
+        /** called continuously while the user is dragging the brush */
         onbrush?: (evt: BrushEvent) => void;
     }
     import { getContext, untrack } from 'svelte';

--- a/src/lib/marks/HTMLTooltip.svelte
+++ b/src/lib/marks/HTMLTooltip.svelte
@@ -4,12 +4,19 @@
 -->
 <script lang="ts" generics="Datum = DataRow">
     interface HTMLTooltipMarkProps {
+        /** the input data array */
         data: Datum[];
+        /** the horizontal position channel; bound to the x scale */
         x?: ChannelAccessor<Datum>;
+        /** the vertical position channel; bound to the y scale */
         y?: ChannelAccessor<Datum>;
+        /** the radius channel, used for positioning with dot-based data */
         r?: ChannelAccessor<Datum>;
+        /** the horizontal facet channel */
         fx?: ChannelAccessor<Datum>;
+        /** the vertical facet channel */
         fy?: ChannelAccessor<Datum>;
+        /** snippet for rendering the tooltip content; receives the nearest datum */
         children: Snippet<[{ datum: Datum }]>;
     }
     import { type Snippet } from 'svelte';

--- a/src/lib/marks/Link.svelte
+++ b/src/lib/marks/Link.svelte
@@ -4,7 +4,9 @@
 
 <script lang="ts" generics="Datum extends DataRecord">
     interface LinkMarkProps extends BaseMarkProps<Datum>, MarkerOptions {
+        /** the input data array; each element becomes one link */
         data: Datum[];
+        /** sort order for data points before rendering */
         sort?: ConstantAccessor<RawValue> | { channel: 'stroke' | 'fill' };
         /**
          * the x1 channel accessor for the start of the link
@@ -18,7 +20,7 @@
          * the x2 channel accessor for the end of the link
          */
         x2: ChannelAccessor<Datum>;
-
+        /** the y2 channel accessor for the end of the link */
         y2: ChannelAccessor<Datum>;
         /**
          * the curve type, defaults to 'auto' which uses a linear curve for planar projections

--- a/src/lib/marks/Pointer.svelte
+++ b/src/lib/marks/Pointer.svelte
@@ -1,11 +1,18 @@
 <script lang="ts" generics="Datum extends DataRow">
     interface PointerMarkProps {
+        /** the input data array */
         data: Datum[];
+        /** snippet rendered with the currently selected data points */
         children?: Snippet<[{ data: Datum[] }]>;
+        /** the horizontal position channel; bound to the x scale */
         x?: ChannelAccessor<Datum>;
+        /** the vertical position channel; bound to the y scale */
         y?: ChannelAccessor<Datum>;
+        /** grouping channel for splitting data into separate search trees */
         z?: ChannelAccessor<Datum>;
+        /** the horizontal facet channel */
         fx?: ChannelAccessor<Datum>;
+        /** the vertical facet channel */
         fy?: ChannelAccessor<Datum>;
         /**
          * maximum cursor distance to select data points

--- a/src/lib/marks/Spike.svelte
+++ b/src/lib/marks/Spike.svelte
@@ -7,11 +7,17 @@
         ComponentProps<typeof Vector>,
         'data' | 'x' | 'y' | 'r' | 'length' | 'rotate'
     > {
+        /** the input data array; each element becomes one spike */
         data: Datum[];
+        /** the horizontal position channel; bound to the x scale */
         x: ChannelAccessor<Datum>;
+        /** the vertical position channel; bound to the y scale */
         y: ChannelAccessor<Datum>;
+        /** the radius (width) of the spike base in pixels */
         r?: number;
+        /** the length of the spike in pixels */
         length?: ChannelAccessor<Datum>;
+        /** rotation angle of the spike in degrees */
         rotate?: ChannelAccessor<Datum>;
     }
     import Vector from './Vector.svelte';

--- a/src/lib/marks/Trail.svelte
+++ b/src/lib/marks/Trail.svelte
@@ -3,16 +3,27 @@
         BaseMarkProps<Datum>,
         'stroke' | 'strokeWidth' | 'strokeDasharray'
     > {
+        /** the input data array */
         data?: Datum[];
+        /** the horizontal position channel; bound to the x scale */
         x?: ChannelAccessor<Datum>;
+        /** the vertical position channel; bound to the y scale */
         y?: ChannelAccessor<Datum>;
+        /** grouping channel for splitting data into separate trails */
         z?: ChannelAccessor<Datum>;
+        /** the radius (width) of the trail at each data point */
         r?: ChannelAccessor<Datum>;
+        /** the curve interpolation type for connecting data points */
         curve?: CurveName | CurveFactory;
+        /** tension parameter for the curve interpolation */
         tension?: number;
+        /** sort order for data points before rendering */
         sort?: ConstantAccessor<RawValue, Datum> | { channel: 'stroke' | 'fill' };
+        /** accessor that returns false for data points that should create gaps in the trail */
         defined?: ConstantAccessor<boolean, Datum>;
+        /** if true, renders using Canvas instead of SVG */
         canvas?: boolean;
+        /** the cap style for trail endpoints */
         cap?: 'butt' | 'round';
         /**
          * Samples per segment for curve interpolation

--- a/src/lib/marks/Vector.svelte
+++ b/src/lib/marks/Vector.svelte
@@ -11,11 +11,17 @@
 
 <script lang="ts" generics="Datum extends DataRecord">
     interface VectorMarkProps extends BaseMarkProps<Datum> {
+        /** the input data array; each element becomes one vector */
         data: Datum[];
+        /** the horizontal position channel; bound to the x scale */
         x: ChannelAccessor<Datum>;
+        /** the vertical position channel; bound to the y scale */
         y: ChannelAccessor<Datum>;
+        /** the radius (width) of the vector shape in pixels */
         r?: number;
+        /** the length of the vector in pixels */
         length?: ChannelAccessor<Datum>;
+        /** rotation angle of the vector in degrees */
         rotate?: ChannelAccessor<Datum>;
         /**
          * Controls where the vector is anchored in relation to the x, y position.
@@ -24,8 +30,11 @@
          * 'end', the arrow will end at the x, y position.
          */
         anchor?: 'start' | 'middle' | 'end';
+        /** the shape of the vector; can be a preset name or a custom ShapeRenderer */
         shape?: 'arrow' | 'spike' | 'arrow-filled' | ShapeRenderer;
+        /** snippet for custom rendering inside the vector mark group */
         children?: Snippet;
+        /** if true, renders using Canvas instead of SVG */
         canvas?: boolean;
     }
     import type {


### PR DESCRIPTION
## Summary
- Add JSDoc comments to undocumented props in **Brush**, **Pointer**, **HTMLTooltip**, **Vector**, **Trail**, **Spike**, and **Link** mark components
- BrushX/BrushY are thin wrappers with no additional props to document
- Follows the same pattern established in #360, #361, and #362

## Details

| Component | Props documented |
|-----------|-----------------|
| Brush | 4 props (brush, onbrushstart, onbrushend, onbrush) |
| Pointer | 7 props (data, children, x, y, z, fx, fy) |
| HTMLTooltip | 7 props (data, x, y, r, fx, fy, children) |
| Vector | 8 props (data, x, y, r, length, rotate, shape, children, canvas) |
| Trail | 11 props (data, x, y, z, r, curve, tension, sort, defined, canvas, cap) |
| Spike | 6 props (data, x, y, r, length, rotate) |
| Link | 3 props (data, sort, y2) |

## Test plan
- [x] `pnpm run lint` passes
- [ ] Verify hovering over component props in editor shows JSDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)