### PR TITLE
docs: add JSDoc to geo, analysis, and remaining mark components

### DIFF
--- a/src/lib/marks/BollingerX.svelte
+++ b/src/lib/marks/BollingerX.svelte
@@ -13,8 +13,11 @@
     import { pick } from 'es-toolkit';
 
     interface BollingerXMarkProps extends BaseMarkProps<Datum> {
+        /** the input data array */
         data: Datum[];
+        /** the horizontal position channel; the dependent variable for the moving average */
         x?: ChannelAccessor<Datum>;
+        /** the vertical position channel; used for grouping */
         y?: ChannelAccessor<Datum>;
         /**
          * the window size (the window transform's k option), an integer; defaults to 20

--- a/src/lib/marks/BollingerY.svelte
+++ b/src/lib/marks/BollingerY.svelte
@@ -13,8 +13,11 @@
     import { pick } from 'es-toolkit';
 
     interface BollingerYMarkProps extends BaseMarkProps<Datum> {
+        /** the input data array */
         data: Datum[];
+        /** the horizontal position channel; used for grouping */
         x?: ChannelAccessor<Datum>;
+        /** the vertical position channel; the dependent variable for the moving average */
         y?: ChannelAccessor<Datum>;
         /**
          * the window size (the window transform's k option), an integer; defaults to 20

--- a/src/lib/marks/BoxY.svelte
+++ b/src/lib/marks/BoxY.svelte
@@ -6,8 +6,11 @@
         BaseMarkProps<Datum>,
         'class' | 'fill' | 'stroke' | 'fx' | 'fy'
     > {
+        /** the input data array */
         data: Datum[];
+        /** the horizontal position channel; bound to a band scale for grouping */
         x: ChannelAccessor;
+        /** the vertical position channel; the quantitative values to summarize */
         y: ChannelAccessor;
         /**
          * Custom sort order for grouped box plot data

--- a/src/lib/marks/ColorLegend.svelte
+++ b/src/lib/marks/ColorLegend.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     interface ColorLegendMarkProps {
+        /** CSS class applied to the legend container element */
         class: string | null;
     }
     import Plot from '../Plot.svelte';

--- a/src/lib/marks/CustomMark.svelte
+++ b/src/lib/marks/CustomMark.svelte
@@ -4,18 +4,29 @@
 -->
 <script lang="ts" generics="Datum extends DataRecord">
     interface CustomMarkProps extends BaseMarkProps<Datum> {
+        /** the input data array */
         data?: Datum[];
+        /** a custom mark type identifier for debugging */
         type?: string;
+        /** the horizontal position channel; bound to the x scale */
         x?: ChannelAccessor<Datum>;
+        /** the starting horizontal position; bound to the x scale */
         x1?: ChannelAccessor<Datum>;
+        /** the ending horizontal position; bound to the x scale */
         x2?: ChannelAccessor<Datum>;
+        /** the vertical position channel; bound to the y scale */
         y?: ChannelAccessor<Datum>;
+        /** the starting vertical position; bound to the y scale */
         y1?: ChannelAccessor<Datum>;
+        /** the ending vertical position; bound to the y scale */
         y2?: ChannelAccessor<Datum>;
+        /** the radius channel; bound to the r scale */
         r?: ChannelAccessor<Datum>;
+        /** snippet rendered once per data point with the scaled record */
         mark?: Snippet<
             [{ record: ScaledDataRecord<Datum>; index: number; usedScales: UsedScales }]
         >;
+        /** snippet rendered once with all scaled records */
         marks?: Snippet<[{ records: ScaledDataRecord<Datum>[]; usedScales: UsedScales }]>;
     }
 

--- a/src/lib/marks/CustomMarkHTML.svelte
+++ b/src/lib/marks/CustomMarkHTML.svelte
@@ -5,9 +5,13 @@
 
 <script lang="ts" generics="Datum extends DataRecord">
     interface CustomMarkHTMLProps {
+        /** the input data array */
         data: Datum[];
+        /** the horizontal position channel; bound to the x scale */
         x?: ChannelAccessor<Datum>;
+        /** the vertical position channel; bound to the y scale */
         y?: ChannelAccessor<Datum>;
+        /** anchor position within the frame when x or y is not specified */
         frameAnchor?: ConstantAccessor<
             | 'bottom'
             | 'top'
@@ -20,7 +24,9 @@
             | 'center',
             Datum
         >;
+        /** CSS class applied to the wrapper element */
         class: string | null;
+        /** snippet rendered for each data point with the datum and its projected coordinates */
         children: Snippet<{ datum: Datum; x: number; y: number }>;
     }
     import { type Snippet } from 'svelte';

--- a/src/lib/marks/DifferenceY.svelte
+++ b/src/lib/marks/DifferenceY.svelte
@@ -1,7 +1,8 @@
 <script lang="ts" generics="Datum extends DataRecord">
     interface DifferenceYMarkProps extends Omit<BaseMarkProps<Datum>, 'fill' | 'fillOpacity'> {
+        /** the input data array */
         data: Datum[];
-        /*
+        /**
          * the horizontal position of the comparison; bound to the x scale
          */
         x1: ChannelAccessor<Datum>;
@@ -9,6 +10,7 @@
          * the horizontal position of the metric; bound to the x scale
          */
         x2: ChannelAccessor<Datum>;
+        /** the shared horizontal position channel; used when x1 and x2 are the same */
         x: ChannelAccessor<Datum>;
         /**
          * the vertical position of the comparison; bound to the y scale
@@ -18,7 +20,9 @@
          * the vertical position of the metric; bound to the y scale
          */
         y2: ChannelAccessor<Datum>;
+        /** the shared vertical position channel; used when y1 and y2 are the same */
         y: ChannelAccessor<Datum>;
+        /** the fill opacity for both positive and negative areas */
         fillOpacity?: number;
         /**
          * the stroke color of the "positive" area; defaults to 'blue'

--- a/src/lib/marks/Frame.svelte
+++ b/src/lib/marks/Frame.svelte
@@ -8,16 +8,27 @@
             Omit<BaseMarkProps<Datum>, 'fill' | 'stroke' | 'fillOpacity' | 'strokeOpacity'>,
             BaseRectMarkProps<Datum>,
             LinkableMarkProps<Datum> {
+        /** the fill color of the frame */
         fill?: string;
+        /** the stroke color of the frame */
         stroke?: string;
+        /** the fill opacity of the frame */
         fillOpacity?: number;
+        /** the stroke opacity of the frame */
         strokeOpacity?: number;
+        /** the overall opacity of the frame */
         opacity?: number;
+        /** whether this frame was automatically added by the Plot component */
         automatic?: boolean;
+        /** shorthand to inset the frame from all edges, in pixels */
         inset?: number;
+        /** inset the frame from the left edge, in pixels */
         insetLeft?: number;
+        /** inset the frame from the right edge, in pixels */
         insetRight?: number;
+        /** inset the frame from the top edge, in pixels */
         insetTop?: number;
+        /** inset the frame from the bottom edge, in pixels */
         insetBottom?: number;
     }
     import Mark from '../Mark.svelte';

--- a/src/lib/marks/Geo.svelte
+++ b/src/lib/marks/Geo.svelte
@@ -3,7 +3,9 @@
 -->
 <script lang="ts" generics="Datum = DataRecord | GeoJSON.GeoJsonObject">
     interface GeoMarkProps extends BaseMarkProps<Datum>, LinkableMarkProps<Datum> {
+        /** the input GeoJSON data array */
         data?: Datum[] | { type: 'Sphere' }[];
+        /** internal: whether this is a sphere or graticule geo mark */
         geoType?: 'sphere' | 'graticule';
         /**
          * todo: implement?
@@ -21,6 +23,7 @@
          * radius for point features
          */
         r?: ChannelAccessor<Datum>;
+        /** SVG filter attribute applied to each geo path element */
         svgFilter?: ConstantAccessor<string | undefined, Datum>;
     }
     import type {

--- a/src/lib/marks/Graticule.svelte
+++ b/src/lib/marks/Graticule.svelte
@@ -7,8 +7,11 @@
         BaseMarkProps<GeoJSON.GeoJsonObject>,
         'fill' | 'fillOpacity' | 'paintOrder' | 'title' | 'href' | 'target' | 'cursor'
     > {
+        /** the step size for both longitude and latitude gridlines in degrees */
         step?: number;
+        /** the step size for longitude gridlines in degrees */
         stepX?: number;
+        /** the step size for latitude gridlines in degrees */
         stepY?: number;
     }
     import Geo from './Geo.svelte';

--- a/src/lib/marks/WaffleX.svelte
+++ b/src/lib/marks/WaffleX.svelte
@@ -21,23 +21,25 @@
 
     interface WaffleXMarkProps
         extends BaseMarkProps<Datum>, LinkableMarkProps<Datum>, WaffleOptions<Datum> {
+        /** the input data array */
         data?: Datum[];
         /**
-         * bound to a quantitative scale
+         * the horizontal position channel; bound to a quantitative scale
          */
         x?: ChannelAccessor<Datum>;
         /**
-         * bound to a quantitative scale
+         * the starting horizontal position; bound to a quantitative scale
          */
         x1?: ChannelAccessor<Datum>;
         /**
-         * bound to a quantitative scale
+         * the ending horizontal position; bound to a quantitative scale
          */
         x2?: ChannelAccessor<Datum>;
         /**
-         * bound to a band scale
+         * the vertical position channel; bound to a band scale
          */
         y?: ChannelAccessor<Datum>;
+        /** stacking options for combining multiple series */
         stack?: StackOptions;
     }
 

--- a/src/lib/marks/WaffleY.svelte
+++ b/src/lib/marks/WaffleY.svelte
@@ -21,21 +21,22 @@
 
     interface WaffleYMarkProps
         extends BaseMarkProps<Datum>, LinkableMarkProps<Datum>, WaffleOptions<Datum> {
+        /** the input data array */
         data?: Datum[];
         /**
-         * bound to a babd scale
+         * the horizontal position channel; bound to a band scale
          */
         x?: ChannelAccessor<Datum>;
         /**
-         * bound to a quantitative scale
+         * the vertical position channel; bound to a quantitative scale
          */
         y?: ChannelAccessor<Datum>;
         /**
-         * bound to a quantitative scale
+         * the starting vertical position; bound to a quantitative scale
          */
         y1?: ChannelAccessor<Datum>;
         /**
-         * bound to a quantitative scale
+         * the ending vertical position; bound to a quantitative scale
          */
         y2?: ChannelAccessor<Datum>;
     }

--- a/src/lib/marks/helpers/Regression.svelte
+++ b/src/lib/marks/helpers/Regression.svelte
@@ -4,8 +4,11 @@
     type RegressionType = 'linear' | 'quad' | 'poly' | 'exp' | 'log' | 'pow' | 'loess';
 
     export type RegressionMarkProps = BaseMarkProps & {
+        /** the horizontal position channel; bound to the x scale */
         x: ChannelAccessor;
+        /** the vertical position channel; bound to the y scale */
         y: ChannelAccessor;
+        /** the regression model type */
         type: RegressionType;
         /**
          * If order is specified, sets the regression's order to the specified number.
@@ -17,11 +20,11 @@
          * it may have little predictive power for data outside of your domain.
          */
         order: number;
-        // for log
+        /** the base for logarithmic regression */
         base: number;
-        // for loess
+        /** the bandwidth for LOESS regression, as a fraction of the data range (0 to 1) */
         span: number;
-        // for confidence bands
+        /** the confidence level for confidence bands (e.g. 0.95 for 95% confidence) */
         confidence: number;
     };
 </script>


### PR DESCRIPTION
## Summary
- Add JSDoc comments to undocumented props in all remaining mark components
- Also documents the shared `RegressionMarkProps` type in the Regression helper
- Fixes a `/*` (non-JSDoc) comment on DifferenceY's `x1` prop to use `/**`
- Follows the same pattern established in #360, #361, #362, and #363

## Details

| Component | Props documented |
|-----------|-----------------|
| Geo | 3 props (data, geoType, svgFilter) |
| Graticule | 3 props (step, stepX, stepY) |
| BollingerX | 3 props (data, x, y) |
| BollingerY | 3 props (data, x, y) |
| BoxY | 3 props (data, x, y) |
| DifferenceY | 4 props (data, x, y, fillOpacity) |
| WaffleX | 6 props (data, x, x1, x2, y, stack) |
| WaffleY | 5 props (data, x, y, y1, y2) |
| Frame | 11 props (fill, stroke, fillOpacity, strokeOpacity, opacity, automatic, inset, insetLeft/Right/Top/Bottom) |
| CustomMark | 11 props (data, type, x, x1, x2, y, y1, y2, r, mark, marks) |
| CustomMarkHTML | 6 props (data, x, y, frameAnchor, class, children) |
| ColorLegend | 1 prop (class) |
| Regression helper | 5 props (x, y, type, base, span, confidence) |

**Not touched** (no new props to document):
- Sphere (inherits all from BaseMarkProps/LinkableMarkProps)
- BoxX (thin wrapper around BoxY)
- RegressionX/Y (re-export RegressionMarkProps from helper)
- SymbolLegend (no props interface)

## Test plan
- [x] `pnpm run lint` passes
- [ ] Verify hovering over component props in editor shows JSDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)