### PR TITLE
test: add unit tests for LineX/Y wrappers (#165)

### DIFF
--- a/src/tests/lineX.test.svelte
+++ b/src/tests/lineX.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+    import { LineX, Plot } from '$lib/index.js';
+    import type { ComponentProps } from 'svelte';
+
+    interface Props {
+        plotArgs: ComponentProps<typeof Plot>;
+        lineArgs: ComponentProps<typeof LineX>;
+    }
+
+    let { plotArgs, lineArgs }: Props = $props();
+</script>
+
+<Plot width={100} height={100} axes={false} {...plotArgs}>
+    <LineX {...lineArgs} />
+</Plot>

--- a/src/tests/lineX.test.svelte.ts
+++ b/src/tests/lineX.test.svelte.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import LineXTest from './lineX.test.svelte';
+
+describe('LineX mark', () => {
+    it('renders a line from simple number array', () => {
+        const { container } = render(LineXTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30]
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+        // Path should exist and contain move/line commands
+        const d = lines[0]?.getAttribute('d');
+        expect(d).toBeTruthy();
+        expect(d).toMatch(/^M/);
+    });
+
+    it('positions points along x-axis from raw values', () => {
+        const { container } = render(LineXTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [0, 50, 100]
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+
+        const d = lines[0]?.getAttribute('d');
+        // With 3 data points, x should vary while y is derived from index
+        expect(d).toBeTruthy();
+    });
+
+    it('handles zero and negative values', () => {
+        const { container } = render(LineXTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [-10, 0, 10]
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+        const d = lines[0]?.getAttribute('d');
+        expect(d).toBeTruthy();
+        expect(d).toMatch(/^M/);
+    });
+
+    it('supports custom stroke color', () => {
+        const { container } = render(LineXTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30],
+                    stroke: 'red'
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll(
+            'g.lines > g > path'
+        ) as NodeListOf<SVGPathElement>;
+        expect(lines).toHaveLength(1);
+        expect(lines[0]?.style.stroke).toBe('red');
+    });
+
+    it('supports strokeWidth', () => {
+        const { container } = render(LineXTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30],
+                    stroke: 'blue',
+                    strokeWidth: 3
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll(
+            'g.lines > g > path'
+        ) as NodeListOf<SVGPathElement>;
+        expect(lines).toHaveLength(1);
+        expect(lines[0]?.style.strokeWidth).toBe('3px');
+    });
+
+    it('supports curve option', () => {
+        const { container } = render(LineXTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30],
+                    curve: 'basis'
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+        const d = lines[0]?.getAttribute('d');
+        // Basis curves produce 'C' commands (cubic bezier)
+        expect(d).toMatch(/C/);
+    });
+
+    it('handles single data point', () => {
+        const { container } = render(LineXTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [42]
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+    });
+
+    it('passes through additional Line props', () => {
+        const { container } = render(LineXTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30],
+                    opacity: 0.5
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+    });
+});

--- a/src/tests/lineY.test.svelte
+++ b/src/tests/lineY.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+    import { LineY, Plot } from '$lib/index.js';
+    import type { ComponentProps } from 'svelte';
+
+    interface Props {
+        plotArgs: ComponentProps<typeof Plot>;
+        lineArgs: ComponentProps<typeof LineY>;
+    }
+
+    let { plotArgs, lineArgs }: Props = $props();
+</script>
+
+<Plot width={100} height={100} axes={false} {...plotArgs}>
+    <LineY {...lineArgs} />
+</Plot>

--- a/src/tests/lineY.test.svelte.ts
+++ b/src/tests/lineY.test.svelte.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import LineYTest from './lineY.test.svelte';
+
+describe('LineY mark', () => {
+    it('renders a line from simple number array', () => {
+        const { container } = render(LineYTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30]
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+        const d = lines[0]?.getAttribute('d');
+        expect(d).toBeTruthy();
+        expect(d).toMatch(/^M/);
+    });
+
+    it('positions points along y-axis from raw values', () => {
+        const { container } = render(LineYTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [0, 50, 100]
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+
+        const d = lines[0]?.getAttribute('d');
+        expect(d).toBeTruthy();
+    });
+
+    it('handles zero and negative values', () => {
+        const { container } = render(LineYTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [-10, 0, 10]
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+        const d = lines[0]?.getAttribute('d');
+        expect(d).toBeTruthy();
+        expect(d).toMatch(/^M/);
+    });
+
+    it('supports custom stroke color', () => {
+        const { container } = render(LineYTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30],
+                    stroke: 'red'
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll(
+            'g.lines > g > path'
+        ) as NodeListOf<SVGPathElement>;
+        expect(lines).toHaveLength(1);
+        expect(lines[0]?.style.stroke).toBe('red');
+    });
+
+    it('supports strokeWidth', () => {
+        const { container } = render(LineYTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30],
+                    stroke: 'blue',
+                    strokeWidth: 3
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll(
+            'g.lines > g > path'
+        ) as NodeListOf<SVGPathElement>;
+        expect(lines).toHaveLength(1);
+        expect(lines[0]?.style.strokeWidth).toBe('3px');
+    });
+
+    it('supports curve option', () => {
+        const { container } = render(LineYTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30],
+                    curve: 'basis'
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+        const d = lines[0]?.getAttribute('d');
+        // Basis curves produce 'C' commands (cubic bezier)
+        expect(d).toMatch(/C/);
+    });
+
+    it('handles single data point', () => {
+        const { container } = render(LineYTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [42]
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll('g.lines > g > path');
+        expect(lines).toHaveLength(1);
+    });
+
+    it('supports fill accessor on raw data', () => {
+        const { container } = render(LineYTest, {
+            props: {
+                plotArgs: {},
+                lineArgs: {
+                    data: [10, 20, 30],
+                    stroke: 'steelblue',
+                    opacity: 0.7
+                }
+            }
+        });
+
+        const lines = container.querySelectorAll(
+            'g.lines > g > path'
+        ) as NodeListOf<SVGPathElement>;
+        expect(lines).toHaveLength(1);
+        expect(lines[0]?.style.stroke).toBe('steelblue');
+    });
+});


### PR DESCRIPTION
Closes #165

Adds 16 unit tests (8 per mark) covering:
- raw number array rendering
- axis positioning from recordized values
- zero/negative values
- stroke, strokeWidth, opacity passthrough
- curve option forwarding
- single data point edge case