### PR TITLE
fix: resolve strict TypeScript errors in integration and component tests

### DIFF
--- a/src/tests/areaY.test.svelte.ts
+++ b/src/tests/areaY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import AreaYTest from './areaY.test.svelte';
 
 describe('AreaY mark', () => {
@@ -99,7 +100,7 @@ describe('AreaY mark', () => {
                     y: 'y',
                     fill: 'g',
                     class: 'my-area-group',
-                    areaClass: (d) => `my-area-${d.g}`
+                    areaClass: (d: any) => `my-area-${d.g}`
                 }
             }
         });

--- a/src/tests/arrow.test.ts
+++ b/src/tests/arrow.test.ts
@@ -172,13 +172,15 @@ describe('Arrow mark', () => {
             }
         });
 
-        const arrows = container.querySelectorAll('g.arrow > g > path');
+        const arrows = container.querySelectorAll(
+            'g.arrow > g > path'
+        ) as NodeListOf<SVGPathElement>;
         expect(arrows.length).toBe(data.length);
         const strokes = Array.from(arrows).map((a) => a.style.stroke);
 
         expect(strokes).toEqual(['red', 'blue', 'green']);
 
-        const x = Array.from(arrows).map((a) => +a.getAttribute('d')?.substring(1).split(',')[0]);
+        const x = Array.from(arrows).map((a) => +a.getAttribute('d')!.substring(1).split(',')[0]);
         expect(x[0]).toBeLessThan(x[1]);
         expect(x[1]).toBeLessThan(x[2]);
     });

--- a/src/tests/axis-properties-fix.test.ts
+++ b/src/tests/axis-properties-fix.test.ts
@@ -56,7 +56,7 @@ test('AxisX and AxisY accept fill, textAnchor, and style properties', () => {
 
     // Test scenario from the issue description
     const styles = {
-        gridLines: 'grid' as const,
+        gridLines: 'grid' as 'grid' | 'ticks',
         fontSize: 12,
         fontColor: '#333',
         lineColor: '#666'

--- a/src/tests/axisX.test.ts
+++ b/src/tests/axisX.test.ts
@@ -216,12 +216,12 @@ describe('AxisX mark', () => {
     });
 
     it('passes index to accessor functions', () => {
-        const checkIndex = vi.fn((d) => d);
+        const checkIndex = vi.fn((d: any) => d);
         const { container } = render(AxisXTest, {
             props: {
                 plotArgs: { width: 500, x: { domain: [0, 100] } },
                 axisArgs: {
-                    tickFontSize: (d, i) => checkIndex(i) + 5
+                    tickFontSize: (d: any, i: number) => checkIndex(i) + 5
                 }
             }
         });
@@ -236,12 +236,12 @@ describe('AxisX mark', () => {
     });
 
     it('passes index to tickFormat functions', () => {
-        const checkIndex = vi.fn((d) => String(d));
+        const checkIndex = vi.fn((d: any) => String(d));
         const { container } = render(AxisXTest, {
             props: {
                 plotArgs: { width: 500, x: { domain: [0, 100] } },
                 axisArgs: {
-                    tickFormat: (d, i) => checkIndex(i)
+                    tickFormat: (d: any, i: number) => checkIndex(i)
                 }
             }
         });
@@ -256,13 +256,13 @@ describe('AxisX mark', () => {
     });
 
     it('passes ticks array to tickFormat functions', () => {
-        const checkTicks = vi.fn((d, i, ticks) => String(d));
+        const checkTicks = vi.fn((d: any, i: number, ticks: any[]) => String(d));
         const { container } = render(AxisXTest, {
             props: {
                 plotArgs: { width: 500, x: { domain: [0, 100] } },
                 axisArgs: {
                     interval: 20,
-                    tickFormat: (d, i, ticks) => checkTicks(d, i, ticks)
+                    tickFormat: (d: any, i: number, ticks: any[]) => checkTicks(d, i, ticks)
                 }
             }
         });
@@ -327,7 +327,7 @@ describe('AxisX mark', () => {
                     x: {
                         domain: [0, 4],
                         ticks: [1, 2, 3, 4],
-                        tickFormat(d, i) {
+                        tickFormat(d: any, i: number) {
                             return [i < 2 ? 'Foo' : 'Bar', d];
                         }
                     }
@@ -357,7 +357,7 @@ describe('AxisX mark', () => {
                         domain: [0, 4],
                         ticks: [1, 2, 3, 4],
                         removeDuplicateTicks: false,
-                        tickFormat(d, i) {
+                        tickFormat(d: any, i: number) {
                             return [i < 2 ? 'Foo' : 'Bar', d];
                         }
                     }

--- a/src/tests/axisY.test.ts
+++ b/src/tests/axisY.test.ts
@@ -138,12 +138,12 @@ describe('AxisY mark', () => {
     });
 
     it('passes index to accessor functions', () => {
-        const checkIndex = vi.fn((d) => d);
+        const checkIndex = vi.fn((d: any) => d);
         const { container } = render(AxisYTest, {
             props: {
                 plotArgs: { height: 250, y: { domain: [0, 100] } },
                 axisArgs: {
-                    tickFontSize: (d, i) => checkIndex(i) + 5
+                    tickFontSize: (d: any, i: number) => checkIndex(i) + 5
                 }
             }
         });
@@ -158,12 +158,12 @@ describe('AxisY mark', () => {
     });
 
     it('passes index to tickFormat functions', () => {
-        const checkIndex = vi.fn((d) => String(d));
+        const checkIndex = vi.fn((d: any) => String(d));
         const { container } = render(AxisYTest, {
             props: {
                 plotArgs: { height: 250, y: { domain: [0, 100] } },
                 axisArgs: {
-                    tickFormat: (d, i) => checkIndex(i)
+                    tickFormat: (d: any, i: number) => checkIndex(i)
                 }
             }
         });
@@ -178,13 +178,13 @@ describe('AxisY mark', () => {
     });
 
     it('passes ticks array to tickFormat functions', () => {
-        const checkTicks = vi.fn((d, i, ticks) => String(d));
+        const checkTicks = vi.fn((d: any, i: number, ticks: any[]) => String(d));
         const { container } = render(AxisYTest, {
             props: {
                 plotArgs: { width: 500, y: { domain: [0, 100] } },
                 axisArgs: {
                     interval: 20,
-                    tickFormat: (d, i, ticks) => checkTicks(d, i, ticks)
+                    tickFormat: (d: any, i: number, ticks: any[]) => checkTicks(d, i, ticks)
                 }
             }
         });

--- a/src/tests/barX.test.svelte.ts
+++ b/src/tests/barX.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, vi, expect } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import BarXTest from './barX.test.svelte';
 import { getPathDims, getRectDims, parsePath } from './utils';
 import { tick } from 'svelte';
@@ -191,15 +192,15 @@ describe('BarX mark', () => {
                 plotArgs: {},
                 barArgs: {
                     data: timeseries,
-                    x: (d, index) => {
+                    x: (d: any, index: number) => {
                         xIndex(index);
                         return d.value;
                     },
-                    fill: (d, index) => {
+                    fill: (d: any, index: number) => {
                         fillIndex(index);
                         return 'steelblue';
                     },
-                    dx: (x, index) => {
+                    dx: (x: any, index: number) => {
                         dxIndex(index);
                         return 0;
                     },
@@ -259,7 +260,7 @@ describe('BarX mark', () => {
                 plotArgs: {},
                 barArgs: {
                     data: [2, -2],
-                    borderRadius: (d) => (d > 0 ? { topRight: 2 } : { topLeft: 2 })
+                    borderRadius: (d: any) => (d > 0 ? { topRight: 2 } : { topLeft: 2 })
                 }
             }
         });
@@ -268,7 +269,7 @@ describe('BarX mark', () => {
         expect(bars.length).toBe(2);
         const paths = Array.from(bars).map((d) =>
             parsePath(d)
-                .map((p) => p.code)
+                .map((p: any) => p.code)
                 .join('')
         );
         expect(paths[0]).toBe('MHAVHVZ');

--- a/src/tests/barY.test.ts
+++ b/src/tests/barY.test.ts
@@ -310,7 +310,7 @@ describe('BarY mark', () => {
                     x: 'label',
                     y: 'value',
                     stack: false,
-                    fill: (d) => (d?.label === 'alpha' ? 'red' : 'blue')
+                    fill: (d: any) => (d?.label === 'alpha' ? 'red' : 'blue')
                 }
             }
         });
@@ -326,10 +326,10 @@ function getRectDims(rect: SVGRectElement) {
         ?.getAttribute('transform')
         ?.match(/translate\((\d+(?:\.\d+)?),(\d+(?:\.\d+)?)\)/);
     return {
-        x: Math.round(+t[1]),
-        y: Math.round(+t[2]),
-        w: Math.round(+rect.getAttribute('width')),
-        h: Math.round(+rect.getAttribute('height')),
+        x: Math.round(+t![1]),
+        y: Math.round(+t![2]),
+        w: Math.round(+rect.getAttribute('width')!),
+        h: Math.round(+rect.getAttribute('height')!),
         fill: rect.style.fill,
         stroke: rect.style.stroke,
         strokeWidth: rect.style.strokeWidth
@@ -337,9 +337,9 @@ function getRectDims(rect: SVGRectElement) {
 }
 
 function getPathDims(path: SVGPathElement) {
-    const r = makeAbsolute(parseSVG(path.getAttribute('d')));
-    const x = r.flatMap((d) => [d.x, d.x0, d.x1]).filter((x) => x != null);
-    const y = r.flatMap((d) => [d.y, d.y0, d.y1]).filter((y) => y != null);
+    const r = makeAbsolute(parseSVG(path.getAttribute('d')!));
+    const x = r.flatMap((d: any) => [d.x, d.x0, d.x1]).filter((x: number | undefined) => x != null);
+    const y = r.flatMap((d: any) => [d.y, d.y0, d.y1]).filter((y: number | undefined) => y != null);
     const t = path
         ?.getAttribute('transform')
         ?.match(/translate\((\d+(?:\.\d+)?),(\d+(?:\.\d+)?)\)/);

--- a/src/tests/bollingerX.test.svelte.ts
+++ b/src/tests/bollingerX.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import BollingerXTest from './bollingerX.test.svelte';
 
 const data = [

--- a/src/tests/bollingerY.test.svelte.ts
+++ b/src/tests/bollingerY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import BollingerYTest from './bollingerY.test.svelte';
 
 const data = [

--- a/src/tests/brush.svelte.test.ts
+++ b/src/tests/brush.svelte.test.ts
@@ -102,12 +102,12 @@ describe('Brush mark', () => {
         // Verify the brush was created/updated
         const updatedRect = container.querySelectorAll('rect.brush-rect');
         expect(updatedRect.length).toBe(1);
-        expect(+updatedRect[0].getAttribute('width')).toBe(((5 - 2) * 400) / 10); // 40 pixels per unit
+        expect(+updatedRect[0].getAttribute('width')!).toBe(((5 - 2) * 400) / 10); // 40 pixels per unit
 
         // Update brush from outside again
         props.brush = { enabled: true, x1: 2, x2: 8, y1: 3, y2: 7 };
         await tick();
 
-        expect(+updatedRect[0].getAttribute('width')).toBe(((8 - 2) * 400) / 10); // 40 pixels per unit
+        expect(+updatedRect[0].getAttribute('width')!).toBe(((8 - 2) * 400) / 10); // 40 pixels per unit
     });
 });

--- a/src/tests/cell.test.svelte.ts
+++ b/src/tests/cell.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, vi, expect } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import CellTest from './cell.test.svelte';
 import { getRectDims, getPathDims } from './utils';
 import { tick } from 'svelte';

--- a/src/tests/cellX.test.svelte.ts
+++ b/src/tests/cellX.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import CellXTest from './cellX.test.svelte';
 import { getRectDims, getPathDims } from './utils';
 

--- a/src/tests/cellY.test.svelte.ts
+++ b/src/tests/cellY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import CellYTest from './cellY.test.svelte';
 import { getRectDims, getPathDims } from './utils';
 

--- a/src/tests/differenceY.test.svelte.ts
+++ b/src/tests/differenceY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import DifferenceYTest from './differenceY.test.svelte';
 
 const data = [

--- a/src/tests/dotX.test.svelte.ts
+++ b/src/tests/dotX.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import DotXTest from './dotX.test.svelte';
 import { getTranslate } from './utils';
 import { symbol, symbolCircle } from 'd3-shape';

--- a/src/tests/dotY.test.svelte.ts
+++ b/src/tests/dotY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import DotYTest from './dotY.test.svelte';
 import { getTranslate } from './utils';
 import { symbol, symbolCircle } from 'd3-shape';

--- a/src/tests/geo.test.svelte.ts
+++ b/src/tests/geo.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import GeoTest from './geo.test.svelte';
 
 const polygon: GeoJSON.Polygon = {

--- a/src/tests/graticule.test.svelte.ts
+++ b/src/tests/graticule.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import GraticuleTest from './graticule.test.svelte';
 
 const projectionArgs = { projection: 'equirectangular' as const };

--- a/src/tests/gridX.test.svelte.ts
+++ b/src/tests/gridX.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import GridXTest from './gridX.test.svelte';
 import { tick } from 'svelte';
 
@@ -54,7 +55,7 @@ describe('GridX mark', () => {
             },
             gridArgs: {
                 dx: 0,
-                dy: 0,
+                dy: 0 as number | (() => number),
                 data: [0, 5, 10]
             }
         });
@@ -82,8 +83,8 @@ describe('GridX mark', () => {
     });
 
     it('passes index to accessor functions', () => {
-        const y1 = vi.fn((d, i) => d + i);
-        const stroke = vi.fn((d, i) => 'gray');
+        const y1 = vi.fn((d: any, i: number) => d + i);
+        const stroke = vi.fn((d: any, i: number) => 'gray');
         render(GridXTest, {
             props: {
                 plotArgs: {

--- a/src/tests/gridY.test.svelte.ts
+++ b/src/tests/gridY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import GridYTest from './gridY.test.svelte';
 import { tick } from 'svelte';
 
@@ -19,7 +20,9 @@ describe('GridY mark', () => {
                 }
             }
         });
-        const gridLines = container.querySelectorAll('g.grid-y > line');
+        const gridLines = container.querySelectorAll(
+            'g.grid-y > line'
+        ) as NodeListOf<SVGLineElement>;
         expect(gridLines.length).toBe(3);
         expect(gridLines[0].style.strokeDasharray).toBe('5, 5');
         expect(gridLines[0].style.stroke).toBe('#008000');
@@ -34,7 +37,7 @@ describe('GridY mark', () => {
             },
             gridArgs: {
                 dx: 0,
-                dy: 0,
+                dy: 0 as number | (() => number),
                 data: [0, 5, 10]
             }
         });
@@ -62,8 +65,8 @@ describe('GridY mark', () => {
     });
 
     it('passes index to accessor functions', () => {
-        const x1 = vi.fn((d, i) => d + i);
-        const stroke = vi.fn((d, i) => 'gray');
+        const x1 = vi.fn((d: any, i: number) => d + i);
+        const stroke = vi.fn((d: any, i: number) => 'gray');
         render(GridYTest, {
             props: {
                 plotArgs: {

--- a/src/tests/line.test.svelte.ts
+++ b/src/tests/line.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import LineTest from './line.test.svelte';
 
 describe('Line mark', () => {
@@ -194,7 +195,7 @@ describe('Line mark', () => {
                 ],
                 x: 'x',
                 y: 'y',
-                text: (d) => d.label
+                text: (d: any) => d.label
             }
         });
 
@@ -213,7 +214,7 @@ describe('Line mark', () => {
                 x: 'x',
                 y: 'y',
                 stroke: 'label',
-                text: (d) => d.label
+                text: (d: any) => d.label
             }
         });
 
@@ -345,14 +346,14 @@ describe('Line mark', () => {
     });
 });
 
-function formatHTML(html) {
+function formatHTML(html: string) {
     var tab = '\t';
     var result = '';
     var indent = '';
 
     html.replace(/<!---->/g, '')
         .split(/>\s*</)
-        .forEach(function (element) {
+        .forEach(function (element: string) {
             if (element.match(/^\/\w/)) {
                 indent = indent.substring(tab.length);
             }

--- a/src/tests/lineX.test.svelte.ts
+++ b/src/tests/lineX.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import LineXTest from './lineX.test.svelte';
 
 describe('LineX mark', () => {

--- a/src/tests/lineY.test.svelte.ts
+++ b/src/tests/lineY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import LineYTest from './lineY.test.svelte';
 
 describe('LineY mark', () => {

--- a/src/tests/link.test.svelte.ts
+++ b/src/tests/link.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import LinkTest from './link.test.svelte';
 
 const twoLinks = [

--- a/src/tests/pointer.test.svelte.ts
+++ b/src/tests/pointer.test.svelte.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import PointerTest from './pointer.test.svelte';
 
 const defaultPlotArgs = {

--- a/src/tests/rect.test.svelte.ts
+++ b/src/tests/rect.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import RectTest from './rect.test.svelte';
 import { getRectDims, getPathDims } from './utils';
 

--- a/src/tests/rectX.test.svelte.ts
+++ b/src/tests/rectX.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import RectXTest from './rectX.test.svelte';
 import { getRectDims } from './utils';
 

--- a/src/tests/rectY.test.svelte.ts
+++ b/src/tests/rectY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import RectYTest from './rectY.test.svelte';
 import { getRectDims } from './utils';
 

--- a/src/tests/regressionX.test.svelte.ts
+++ b/src/tests/regressionX.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import RegressionXTest from './regressionX.test.svelte';
 
 const linearData = [

--- a/src/tests/regressionY.test.svelte.ts
+++ b/src/tests/regressionY.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import RegressionYTest from './regressionY.test.svelte';
 
 const linearData = [

--- a/src/tests/ruleX.test.ts
+++ b/src/tests/ruleX.test.ts
@@ -53,8 +53,8 @@ describe('RuleX mark', () => {
         expect(rules.length).toBe(3);
 
         rules.forEach((rule) => {
-            const y1 = parseFloat(rule.getAttribute('y1'));
-            const y2 = parseFloat(rule.getAttribute('y2'));
+            const y1 = parseFloat(rule.getAttribute('y1')!);
+            const y2 = parseFloat(rule.getAttribute('y2')!);
             // Rules should span from margin to bottom
             expect(y1).toBeLessThan(y2);
             expect(y2 - y1).toBeGreaterThan(50); // Should span most of plot height
@@ -83,8 +83,8 @@ describe('RuleX mark', () => {
 
         expect(rules.length).toBe(1);
         // dy affects the y1/y2 positions of the vertical line
-        const y1 = parseFloat(rules[0].getAttribute('y1'));
-        const y2 = parseFloat(rules[0].getAttribute('y2'));
+        const y1 = parseFloat(rules[0].getAttribute('y1')!);
+        const y2 = parseFloat(rules[0].getAttribute('y2')!);
 
         // Both y1 and y2 should have the dy offset applied
         // With dy=10 and marginTop=5 (default), y1 should be at least 10+5=15
@@ -130,8 +130,8 @@ describe('RuleX mark', () => {
         });
 
         const rule = container.querySelector('g.rule-x > line') as SVGLineElement;
-        const y1 = parseFloat(rule.getAttribute('y1'));
-        const y2 = parseFloat(rule.getAttribute('y2'));
+        const y1 = parseFloat(rule.getAttribute('y1')!);
+        const y2 = parseFloat(rule.getAttribute('y2')!);
 
         // Both ends should be inset by 10
         expect(y1).toBeGreaterThanOrEqual(10);
@@ -155,8 +155,8 @@ describe('RuleX mark', () => {
         });
 
         const rule = container.querySelector('g.rule-x > line') as SVGLineElement;
-        const y1 = parseFloat(rule.getAttribute('y1'));
-        const y2 = parseFloat(rule.getAttribute('y2'));
+        const y1 = parseFloat(rule.getAttribute('y1')!);
+        const y2 = parseFloat(rule.getAttribute('y2')!);
 
         // Top should be inset by 5
         expect(y1).toBeGreaterThanOrEqual(5);
@@ -180,8 +180,8 @@ describe('RuleX mark', () => {
         });
 
         const rule = container.querySelector('g.rule-x > line') as SVGLineElement;
-        const y1 = parseFloat(rule.getAttribute('y1'));
-        const y2 = parseFloat(rule.getAttribute('y2'));
+        const y1 = parseFloat(rule.getAttribute('y1')!);
+        const y2 = parseFloat(rule.getAttribute('y2')!);
 
         // Should use specified y1/y2 values (scaled)
         // Y-axis is inverted in SVG, so y1 (20) appears lower (higher value) than y2 (80)
@@ -227,8 +227,8 @@ describe('RuleX mark', () => {
     });
 
     it('passes index to accessor functions', () => {
-        const y1 = vi.fn((d, i) => i * 10);
-        const stroke = vi.fn((d, i) => 'gray');
+        const y1 = vi.fn((d: any, i: number) => i * 10);
+        const stroke = vi.fn((d: any, i: number) => 'gray');
         render(RuleXTest, {
             props: {
                 plotArgs: {

--- a/src/tests/ruleY.test.ts
+++ b/src/tests/ruleY.test.ts
@@ -55,8 +55,8 @@ describe('RuleY mark', () => {
         expect(rules.length).toBe(3);
 
         rules.forEach((rule) => {
-            const x1 = parseFloat(rule.getAttribute('x1'));
-            const x2 = parseFloat(rule.getAttribute('x2'));
+            const x1 = parseFloat(rule.getAttribute('x1')!);
+            const x2 = parseFloat(rule.getAttribute('x2')!);
             // Rules should span from margin to right edge
             expect(x1).toBeLessThan(x2);
             expect(x2 - x1).toBeGreaterThan(50); // Should span most of plot width
@@ -85,8 +85,8 @@ describe('RuleY mark', () => {
 
         expect(rules.length).toBe(1);
         // dx affects the x1/x2 positions of the horizontal line
-        const x1 = parseFloat(rules[0].getAttribute('x1'));
-        const x2 = parseFloat(rules[0].getAttribute('x2'));
+        const x1 = parseFloat(rules[0].getAttribute('x1')!);
+        const x2 = parseFloat(rules[0].getAttribute('x2')!);
 
         // Both x1 and x2 should have the dx offset applied
         // With dx=20 and marginLeft=5 (default), x1 should be at least 20+5=25
@@ -132,8 +132,8 @@ describe('RuleY mark', () => {
         });
 
         const rule = container.querySelector('g.rule-y > line') as SVGLineElement;
-        const x1 = parseFloat(rule.getAttribute('x1'));
-        const x2 = parseFloat(rule.getAttribute('x2'));
+        const x1 = parseFloat(rule.getAttribute('x1')!);
+        const x2 = parseFloat(rule.getAttribute('x2')!);
 
         // Both ends should be inset by 10
         expect(x1).toBeGreaterThanOrEqual(10);
@@ -157,8 +157,8 @@ describe('RuleY mark', () => {
         });
 
         const rule = container.querySelector('g.rule-y > line') as SVGLineElement;
-        const x1 = parseFloat(rule.getAttribute('x1'));
-        const x2 = parseFloat(rule.getAttribute('x2'));
+        const x1 = parseFloat(rule.getAttribute('x1')!);
+        const x2 = parseFloat(rule.getAttribute('x2')!);
 
         // Left should be inset by 5
         expect(x1).toBeGreaterThanOrEqual(5);
@@ -182,8 +182,8 @@ describe('RuleY mark', () => {
         });
 
         const rule = container.querySelector('g.rule-y > line') as SVGLineElement;
-        const x1 = parseFloat(rule.getAttribute('x1'));
-        const x2 = parseFloat(rule.getAttribute('x2'));
+        const x1 = parseFloat(rule.getAttribute('x1')!);
+        const x2 = parseFloat(rule.getAttribute('x2')!);
 
         // Should use specified x1/x2 values (scaled)
         expect(x1).toBeLessThan(x2);
@@ -227,8 +227,8 @@ describe('RuleY mark', () => {
     });
 
     it('passes index to accessor functions', () => {
-        const x1 = vi.fn((d, i) => i * 10);
-        const stroke = vi.fn((d, i) => 'gray');
+        const x1 = vi.fn((d: any, i: number) => i * 10);
+        const stroke = vi.fn((d: any, i: number) => 'gray');
         render(RuleYTest, {
             props: {
                 plotArgs: {

--- a/src/tests/sphere.test.svelte.ts
+++ b/src/tests/sphere.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import SphereTest from './sphere.test.svelte';
 
 const projectionArgs = { projection: 'equirectangular' as const };

--- a/src/tests/spike.test.svelte.ts
+++ b/src/tests/spike.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import SpikeTest from './spike.test.svelte';
 
 const data = [

--- a/src/tests/text.test.svelte.ts
+++ b/src/tests/text.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import TextTest from './text.test.svelte';
 import { getTranslate } from './utils';
 import { tick } from 'svelte';

--- a/src/tests/tickX.test.ts
+++ b/src/tests/tickX.test.ts
@@ -33,9 +33,9 @@ describe('TickX mark', () => {
             [48.5, 0],
             [86, 0]
         ]);
-        const y1 = ticks.map((tick) => parseFloat(tick.getAttribute('y1')));
+        const y1 = ticks.map((tick) => parseFloat(tick.getAttribute('y1')!));
         expect(y1).toEqual([0, 0, 0]);
-        const y2 = ticks.map((tick) => parseFloat(tick.getAttribute('y2')));
+        const y2 = ticks.map((tick) => parseFloat(tick.getAttribute('y2')!));
         expect(y2).toEqual([95, 95, 95]);
     });
 

--- a/src/tests/tickY.test.ts
+++ b/src/tests/tickY.test.ts
@@ -30,9 +30,9 @@ describe('TickY mark', () => {
             [0, 50],
             [0, 15]
         ]);
-        const x1 = ticks.map((tick) => parseFloat(tick.getAttribute('x1')));
+        const x1 = ticks.map((tick) => parseFloat(tick.getAttribute('x1')!));
         expect(x1).toEqual([1, 1, 1]);
-        const x2 = ticks.map((tick) => parseFloat(tick.getAttribute('x2')));
+        const x2 = ticks.map((tick) => parseFloat(tick.getAttribute('x2')!));
         expect(x2).toEqual([100, 100, 100]);
     });
 

--- a/src/tests/trail.test.svelte.ts
+++ b/src/tests/trail.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import TrailTest from './trail.test.svelte';
 
 describe('Trail mark', () => {
@@ -82,7 +83,7 @@ describe('Trail mark', () => {
                 x: 'x',
                 y: 'y',
                 r: 1,
-                defined: (d) => d.keep,
+                defined: (d: any) => d.keep,
                 resolution: 1,
                 cap: 'butt'
             }

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -5,10 +5,10 @@ export function getRectDims(rect: SVGRectElement) {
         ?.getAttribute('transform')
         ?.match(/translate\((\d+(?:\.\d+)?),(\d+(?:\.\d+)?)\)/);
     return {
-        x: Math.round(+t[1]),
-        y: Math.round(+t[2]),
-        w: Math.round(+rect.getAttribute('width')),
-        h: Math.round(+rect.getAttribute('height')),
+        x: Math.round(+t![1]),
+        y: Math.round(+t![2]),
+        w: Math.round(+rect.getAttribute('width')!),
+        h: Math.round(+rect.getAttribute('height')!),
         fill: rect.style.fill,
         stroke: rect.style.stroke,
         strokeWidth: rect.style.strokeWidth
@@ -24,9 +24,9 @@ export function getTranslate(element: SVGElement) {
 }
 
 export function getPathDims(path: SVGPathElement) {
-    const r = makeAbsolute(parseSVG(path.getAttribute('d')));
-    const x = r.flatMap((d) => [d.x, d.x0, d.x1]).filter((x) => x != null);
-    const y = r.flatMap((d) => [d.y, d.y0, d.y1]).filter((y) => y != null);
+    const r = makeAbsolute(parseSVG(path.getAttribute('d')!));
+    const x = r.flatMap((d: any) => [d.x, d.x0, d.x1]).filter((x: number | undefined) => x != null);
+    const y = r.flatMap((d: any) => [d.y, d.y0, d.y1]).filter((y: number | undefined) => y != null);
     const [tx, ty] = getTranslate(path);
     return {
         x: Math.round(Math.min(...x)) + tx,
@@ -40,5 +40,5 @@ export function getPathDims(path: SVGPathElement) {
 }
 
 export function parsePath(path: SVGPathElement) {
-    return makeAbsolute(parseSVG(path.getAttribute('d')));
+    return makeAbsolute(parseSVG(path.getAttribute('d')!));
 }

--- a/src/tests/vector.test.svelte.ts
+++ b/src/tests/vector.test.svelte.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
+// @ts-expect-error - Svelte component has no typed default export
 import VectorTest from './vector.test.svelte';
 
 const data = [


### PR DESCRIPTION
## Summary

- Fix ~116 strict TypeScript errors across 40 test files in `src/tests/`
- Add `// @ts-expect-error` for Svelte component imports lacking typed default exports (TS1192)
- Add explicit type annotations on callback parameters (TS7006)
- Add non-null assertions on `getAttribute()` calls (TS2345/TS2531)
- Add `NodeListOf<SVGElement>` casts for DOM queries (TS2339)
- Fix type narrowing for union types (TS2367/TS2322)
- Remove unused `@ts-expect-error` directives (TS2578)

This is PR 5 of 5 in the strict TypeScript error resolution series. Builds on PR 4 (remaining transform/helper tests).

## Test plan

- [x] `pnpm lint:types` — zero errors in modified files
- [x] All 399 tests pass across 51 test files
- [x] Prettier formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)