### PR TITLE
Normalize Plot grid defaults and support boolean shorthand

### DIFF
--- a/src/lib/core/Plot.svelte
+++ b/src/lib/core/Plot.svelte
@@ -59,6 +59,11 @@
 
     // default settings in the plot and marks can be overwritten by
     // defining the svelteplot/defaults context outside of Plot
+    const asGridDefaults = (opts: PlotDefaults['grid'] | undefined) =>
+        opts === true ? { implicit: true } : opts == null ? {} : opts;
+    const isImplicit = (opts: { implicit?: boolean } | true | undefined) =>
+        opts === true ? true : (opts?.implicit ?? false);
+
     const DEFAULTS: PlotDefaults = {
         height: 350,
         initialWidth: 500,
@@ -93,13 +98,13 @@
         },
         gridX: {
             implicit: false,
-            ...USER_DEFAULTS.grid,
-            ...USER_DEFAULTS.gridX
+            ...asGridDefaults(USER_DEFAULTS.grid),
+            ...asGridDefaults(USER_DEFAULTS.gridX)
         },
         gridY: {
             implicit: false,
-            ...USER_DEFAULTS.grid,
-            ...USER_DEFAULTS.gridY
+            ...asGridDefaults(USER_DEFAULTS.grid),
+            ...asGridDefaults(USER_DEFAULTS.gridY)
         }
     };
 
@@ -444,9 +449,9 @@
             marginTop: maybeMargin(margin, 'top', DEFAULTS.margin, autoMargins),
             marginBottom: maybeMargin(margin, 'bottom', DEFAULTS.margin, autoMargins),
             inset: isOneDimensional ? 10 : DEFAULTS.inset,
-            grid: (DEFAULTS.gridX?.implicit ?? false) && (DEFAULTS.gridY?.implicit ?? false),
+            grid: isImplicit(DEFAULTS.gridX) && isImplicit(DEFAULTS.gridY),
             axes: (DEFAULTS.axisX?.implicit ?? false) && (DEFAULTS.axisY?.implicit ?? false),
-            frame: DEFAULTS.frame?.implicit ?? false,
+            frame: isImplicit(DEFAULTS.frame),
             projection: null,
             aspectRatio: null,
             facet: {},
@@ -464,7 +469,7 @@
                 align: 0.5,
                 tickSpacing: DEFAULTS.axisX.tickSpacing ?? 80,
                 tickFormat: 'auto',
-                grid: DEFAULTS.gridX.implicit ?? false
+                grid: isImplicit(DEFAULTS.gridX)
             },
             y: {
                 type: 'auto',
@@ -479,7 +484,7 @@
                 align: 0.5,
                 tickSpacing: DEFAULTS.axisY.tickSpacing ?? 50,
                 tickFormat: 'auto',
-                grid: DEFAULTS.gridY.implicit ?? false
+                grid: isImplicit(DEFAULTS.gridY)
             },
             opacity: {
                 type: 'linear',

--- a/src/lib/hooks/plotDefaults.ts
+++ b/src/lib/hooks/plotDefaults.ts
@@ -6,7 +6,8 @@ const PLOT_DEFAULTS_KEY = Symbol('svelteplot/defaults');
 /** sets default options for all Plot components in this component tree, merging with any existing defaults from parent contexts */
 export function setPlotDefaults(plotDefaults: Partial<PlotDefaults>) {
     const existingDefaults = getPlotDefaults();
-    const mergedDefaults = { ...existingDefaults, ...plotDefaults };
+    const normalizedDefaults = normalizePlotDefaults(plotDefaults, existingDefaults);
+    const mergedDefaults = { ...existingDefaults, ...normalizedDefaults };
     setContext(PLOT_DEFAULTS_KEY, mergedDefaults);
 }
 
@@ -21,4 +22,44 @@ export function getPlotDefaults(): Partial<PlotDefaults> {
             ),
             getContext<PlotDefaults>('svelteplot/defaults'))
           : {};
+}
+
+function normalizePlotDefaults(
+    plotDefaults: Partial<PlotDefaults>,
+    existingDefaults: Partial<PlotDefaults>
+): Partial<PlotDefaults> {
+    const grid = normalizeGridDefaults(plotDefaults.grid, existingDefaults.grid);
+    const gridX = normalizeGridDefaults(plotDefaults.gridX, existingDefaults.gridX);
+    const gridY = normalizeGridDefaults(plotDefaults.gridY, existingDefaults.gridY);
+    const frame = normalizeFrameDefaults(plotDefaults.frame, existingDefaults.frame);
+
+    return {
+        ...plotDefaults,
+        ...(grid !== undefined ? { grid } : {}),
+        ...(gridX !== undefined ? { gridX } : {}),
+        ...(gridY !== undefined ? { gridY } : {}),
+        ...(frame !== undefined ? { frame } : {})
+    };
+}
+
+function normalizeGridDefaults(
+    input: Partial<PlotDefaults['grid']> | true | undefined,
+    existing: Partial<PlotDefaults['grid']> | true | undefined
+) {
+    if (input !== true) return input;
+    return {
+        ...(typeof existing === 'object' ? existing : {}),
+        implicit: true
+    };
+}
+
+function normalizeFrameDefaults(
+    input: Partial<PlotDefaults['frame']> | true | undefined,
+    existing: Partial<PlotDefaults['frame']> | true | undefined
+) {
+    if (input !== true) return input;
+    return {
+        ...(typeof existing === 'object' ? existing : {}),
+        implicit: true
+    };
 }

--- a/src/lib/types/plot.ts
+++ b/src/lib/types/plot.ts
@@ -268,7 +268,7 @@ export type PlotDefaults = {
     /**
      * default props for frame marks
      */
-    frame: Partial<ComponentProps<typeof Frame> & { implicit: boolean }>;
+    frame: Partial<ComponentProps<typeof Frame> & { implicit: boolean }> | true;
     /**
      * default props for geo marks
      */
@@ -280,15 +280,21 @@ export type PlotDefaults = {
     /**
      * default props for grid marks, applied to both gridX and gridY marks
      */
-    grid: Partial<Omit<ComponentProps<typeof GridX>, IgnoreDefaults> & { implicit: boolean }>;
+    grid:
+        | Partial<Omit<ComponentProps<typeof GridX>, IgnoreDefaults> & { implicit: boolean }>
+        | true;
     /**
      * default props for gridX marks
      */
-    gridX: Partial<Omit<ComponentProps<typeof GridX>, IgnoreDefaults> & { implicit: boolean }>;
+    gridX:
+        | Partial<Omit<ComponentProps<typeof GridX>, IgnoreDefaults> & { implicit: boolean }>
+        | true;
     /**
      * default props for gridY marks
      */
-    gridY: Partial<Omit<ComponentProps<typeof GridY>, IgnoreDefaults> & { implicit: boolean }>;
+    gridY:
+        | Partial<Omit<ComponentProps<typeof GridY>, IgnoreDefaults> & { implicit: boolean }>
+        | true;
     /**
      * default props for image marks
      */

--- a/src/routes/features/defaults/+page.md
+++ b/src/routes/features/defaults/+page.md
@@ -119,7 +119,7 @@ Setting Global and Component Defaults
             tickSize: 0,
             tickPadding: 5
         },
-        frame: { implicit: true },
+        frame: true,
         grid: { implicit: true },
         dot: {
             r: 5
@@ -153,7 +153,7 @@ setPlotDefaults({
         tickSize: 0,
         tickPadding: 5
     },
-    frame: { implicit: true },
+    frame: true,
     grid: { implicit: true },
     dot: {
         r: 5

--- a/src/tests/plot.test.ts
+++ b/src/tests/plot.test.ts
@@ -188,6 +188,21 @@ describe('Plot component', () => {
         expect(svg?.getAttribute('height')).toBe('150');
     });
 
+    it('supports implicit frame via setPlotDefaults({ frame: true })', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                defaults: { frame: true },
+                plotArgs: {
+                    width: 100,
+                    height: 100
+                }
+            }
+        });
+
+        const rect = container.querySelector('svg rect.frame');
+        expect(rect).not.toBeNull();
+    });
+
     it('initial margins', () => {
         const { container } = render(PlotTest, {
             props: {
@@ -515,5 +530,24 @@ describe('Implicit axes', () => {
         // Check for right placement by examining tick positions
         const yTicks = svg?.querySelectorAll('g.axis-y .tick');
         expect(yTicks?.length).toBeGreaterThan(0);
+    });
+});
+
+describe('Implicit grids', () => {
+    it('enables implicit grids from setPlotDefaults({ grid: true })', () => {
+        const { container } = render(PlotTest, {
+            props: {
+                defaults: { grid: true },
+                plotArgs: {
+                    width: 100,
+                    height: 100,
+                    x: { domain: [0, 10] },
+                    y: { domain: [0, 10] }
+                }
+            }
+        });
+
+        expect(container.querySelectorAll('g.grid-x line').length).toBeGreaterThan(0);
+        expect(container.querySelectorAll('g.grid-y line').length).toBeGreaterThan(0);
     });
 });

--- a/src/tests/plotDefaults.test.ts
+++ b/src/tests/plotDefaults.test.ts
@@ -49,4 +49,46 @@ describe('plotDefaults', () => {
             height: 300
         });
     });
+
+    it('supports boolean grid shorthand for top-level Plot grid default', () => {
+        const { container } = render(PlotDefaultsTest, {
+            props: { defaults: { grid: true } }
+        });
+        expect(getDefaults(container)).toEqual({
+            grid: { implicit: true }
+        });
+    });
+
+    it('keeps grid mark defaults when grid shorthand is set in child context', () => {
+        const { container } = render(PlotDefaultsNestedTest, {
+            props: {
+                parentDefaults: { grid: { stroke: 'crimson' } },
+                childDefaults: { grid: true }
+            }
+        });
+        expect(getDefaults(container)).toEqual({
+            grid: { stroke: 'crimson', implicit: true }
+        });
+    });
+
+    it('supports boolean frame shorthand for top-level Plot frame default', () => {
+        const { container } = render(PlotDefaultsTest, {
+            props: { defaults: { frame: true } }
+        });
+        expect(getDefaults(container)).toEqual({
+            frame: { implicit: true }
+        });
+    });
+
+    it('keeps frame mark defaults when frame shorthand is set in child context', () => {
+        const { container } = render(PlotDefaultsNestedTest, {
+            props: {
+                parentDefaults: { frame: { stroke: 'crimson' } },
+                childDefaults: { frame: true }
+            }
+        });
+        expect(getDefaults(container)).toEqual({
+            frame: { stroke: 'crimson', implicit: true }
+        });
+    });
 });


### PR DESCRIPTION
Summary
- allow `setPlotDefaults` to accept `true` as shorthand for turning on implicit grids and frame
- normalize inherited grid defaults so gridX/gridY reuse shared settings and support the new boolean shortcut
- add regression tests covering implicit grids and default normalization
Testing
- Not run (not requested)