### PR TITLE
fix: resolve svelte-check issues in Image mark

### DIFF
--- a/src/lib/marks/CustomMark.svelte
+++ b/src/lib/marks/CustomMark.svelte
@@ -6,8 +6,6 @@
     interface CustomMarkProps extends BaseMarkProps<Datum> {
         /** the input data array */
         data?: Datum[];
-        /** a custom mark type identifier for debugging */
-        type?: string;
         /** the horizontal position channel; bound to the x scale */
         x?: ChannelAccessor<Datum>;
         /** the starting horizontal position; bound to the x scale */
@@ -37,7 +35,8 @@
         BaseMarkProps,
         ScaledDataRecord,
         UsedScales,
-        ScaledChannelName
+        ScaledChannelName,
+        MarkType
     } from 'svelteplot/types/index.js';
     import type { Snippet } from 'svelte';
     import { sort } from '../index.js';
@@ -70,7 +69,7 @@
     ];
 </script>
 
-<Mark {type} required={[]} channels={channels.filter((d) => !!options[d])} {...args}>
+<Mark type="custom" required={[]} channels={channels.filter((d) => !!options[d])} {...args}>
     {#snippet children({ scaledData, usedScales })}
         {#if marks}
             {@render marks({ records: scaledData.filter((d) => d.valid), usedScales })}

--- a/src/lib/marks/helpers/Anchor.svelte
+++ b/src/lib/marks/helpers/Anchor.svelte
@@ -5,10 +5,25 @@
     interface AnchorProps {
         datum?: Datum;
         options?: {
+            /**
+             * The URL or URL fragment the hyperlink points to.
+             */
             href?: ConstantAccessor<string, Datum>;
+            /**
+             * Where to display the linked URL, e.g. _self, _blank
+             */
             target?: ConstantAccessor<string, Datum>;
+            /**
+             * The relationship of the target object to the link object.
+             */
             rel?: ConstantAccessor<string, Datum>;
+            /**
+             * A MIME type for the linked URL.
+             */
             type?: ConstantAccessor<string, Datum>;
+            /**
+             * Instructs browsers to download a URL instead of navigating to it, so the user will be prompted to save it as a local file.
+             */
             download?: ConstantAccessor<string, Datum>;
             [key: string]: any;
         };

--- a/src/lib/types/mark.ts
+++ b/src/lib/types/mark.ts
@@ -20,6 +20,7 @@ export type MarkType =
     | 'geo'
     | 'gridX'
     | 'gridY'
+    | 'image'
     | 'line'
     | 'rect'
     | 'regression'
@@ -261,7 +262,7 @@ export type LinkableMarkProps<T> = {
      * if set to true, the link will be downloaded instead of navigating to it
      * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download
      */
-    download?: ConstantAccessor<boolean, T>;
+    download?: ConstantAccessor<string, T>;
     // allow data-sveltekit-* attributes on the link element, e.g. data-sveltekit-reload
     [key: `data-sveltekit-${string}`]: unknown;
 };

--- a/src/routes/examples/image/image-beeswarm.svelte
+++ b/src/routes/examples/image/image-beeswarm.svelte
@@ -11,7 +11,6 @@
 
 <script lang="ts">
     import { Plot, Image } from 'svelteplot';
-    import RuleY from 'svelteplot/marks/RuleY.svelte';
     import type { ExamplesData } from '../types';
     const { presidents2 } = $props() as ExamplesData;
 </script>


### PR DESCRIPTION
resolves #436 

Summary
- switch `Image` to use the base `Mark` component so it adheres to the svelte-check requirements and restores the image mark type
- keep image rendering logic inside the mark while surfacing only the allowed channels and defaults
- Sub-issues: 1, 2

Testing
- Not run (not requested)