### PR TITLE
Fix tick mark rendering and typing for svelte-check

### DIFF
--- a/src/lib/marks/helpers/TickCanvas.svelte
+++ b/src/lib/marks/helpers/TickCanvas.svelte
@@ -96,17 +96,17 @@
                 };
 
                 const prepareStyle = (datum: ScaledDataRecord<Datum>) => {
-                    let { stroke, ...restStyles } = resolveScaledStyleProps(
+                    const styleProps = resolveScaledStyleProps(
                         datum.datum,
                         options,
                         usedScales,
                         plot,
                         'stroke'
-                    );
+                    ) as Record<string, unknown>;
 
-                    const opacity = maybeOpacity(restStyles['opacity']);
-                    const strokeOpacity = maybeOpacity(restStyles['stroke-opacity']);
-                    const lineCap = normalizeLineCap(restStyles['stroke-linecap']);
+                    const opacity = maybeOpacity(styleProps['opacity']);
+                    const strokeOpacity = maybeOpacity(styleProps['stroke-opacity']);
+                    const lineCap = normalizeLineCap(styleProps['stroke-linecap']);
                     const strokeWidth = +(resolveProp(
                         options.strokeWidth,
                         datum.datum,
@@ -121,6 +121,7 @@
                         | number
                         | string;
 
+                    const stroke = styleProps.stroke;
                     const strokeValue = String(stroke || 'currentColor');
                     const alpha = opacity * strokeOpacity;
                     const styleKey = `${strokeValue}|${lineCap}|${strokeWidth}|${alpha}`;

--- a/src/routes/examples/tick/tick-x-canvas-vs-svg.svelte
+++ b/src/routes/examples/tick/tick-x-canvas-vs-svg.svelte
@@ -6,10 +6,16 @@
     export const sortKey = 21;
 </script>
 
-<script>
+<script lang="ts">
     import { Plot, RuleX, TickX } from 'svelteplot';
 
-    let { stateage } = $props();
+    type StateAgeRow = {
+        age: string;
+        pop_share: number;
+    };
+
+    let { stateage }: { stateage: StateAgeRow[] } =
+        $props();
 
     let ageDomain = $derived([
         ...new Set(stateage.map((d) => d.age))

--- a/src/routes/examples/tick/tick-x.svelte
+++ b/src/routes/examples/tick/tick-x.svelte
@@ -4,9 +4,16 @@
     export const data = { stateage: '/data/stateage.csv' };
 </script>
 
-<script>
+<script lang="ts">
     import { Plot, RuleX, TickX } from 'svelteplot';
-    let { stateage } = $props();
+
+    type StateAgeRow = {
+        age: string;
+        pop_share: number;
+    };
+
+    let { stateage }: { stateage: StateAgeRow[] } =
+        $props();
 </script>
 
 <Plot


### PR DESCRIPTION
Resolves #447
Resolves #448
Resolves #470 

Summary
- reworked `TickX`/`TickY` to rely on scaled data, simplify props, and replace manual channel resolution for better type safety
- ensured `TickCanvas` uses consistent style props and extended example scripts with explicit typings
Testing
- Not run (not requested)