### PR TITLE
Fix svelte-check issues in mark components

### DIFF
--- a/src/lib/marks/BoxX.svelte
+++ b/src/lib/marks/BoxX.svelte
@@ -19,10 +19,10 @@
         ...getPlotDefaults().boxX
     };
 
-    const props: BoxXMarkProps & { class?: string } = $derived({
+    const resolvedProps = $derived({
         ...DEFAULTS,
         ...markProps
-    });
+    }) as BoxXMarkProps & { class?: string };
 </script>
 
-<Box {...props} orientation="x" />
+<Box {...resolvedProps as any} orientation="x" />

--- a/src/lib/marks/BoxY.svelte
+++ b/src/lib/marks/BoxY.svelte
@@ -62,10 +62,10 @@
         ...getPlotDefaults().boxY
     };
 
-    const props: BoxYMarkProps & { class?: string } = $derived({
+    const resolvedProps = $derived({
         ...DEFAULTS,
         ...markProps
-    });
+    }) as BoxYMarkProps & { class?: string };
 </script>
 
-<Box {...props} orientation="y" />
+<Box {...resolvedProps as any} orientation="y" />

--- a/src/lib/marks/CustomMark.svelte
+++ b/src/lib/marks/CustomMark.svelte
@@ -29,27 +29,19 @@
     }
 
     import type {
-        PlotContext,
         DataRecord,
         ChannelAccessor,
         BaseMarkProps,
         ScaledDataRecord,
         UsedScales,
-        ScaledChannelName,
-        MarkType
+        ScaledChannelName
     } from 'svelteplot/types/index.js';
     import type { Snippet } from 'svelte';
     import { sort } from '../index.js';
 
     import Mark from 'svelteplot/Mark.svelte';
 
-    let {
-        data = [{} as Datum],
-        mark,
-        type = 'custom',
-        marks,
-        ...options
-    }: CustomMarkProps = $props();
+    let { data = [{} as Datum], mark, marks, ...options }: CustomMarkProps = $props();
 
     const args = $derived(sort({ data, ...options })) as CustomMarkProps;
 
@@ -69,7 +61,11 @@
     ];
 </script>
 
-<Mark type="custom" required={[]} channels={channels.filter((d) => !!options[d])} {...args}>
+<Mark
+    type="custom"
+    required={[]}
+    channels={channels.filter((d) => !!(options as Record<string, unknown>)[d])}
+    {...args}>
     {#snippet children({ scaledData, usedScales })}
         {#if marks}
             {@render marks({ records: scaledData.filter((d) => d.valid), usedScales })}

--- a/src/lib/marks/Image.svelte
+++ b/src/lib/marks/Image.svelte
@@ -63,7 +63,7 @@
         ...markProps
     });
 
-    const args = $derived(sort({ data, ...options } as TransformArg<Datum>) as ImageMarkProps);
+    const args = $derived(sort({ data, ...options } as TransformArg<Datum>));
 </script>
 
 <Mark

--- a/src/lib/marks/RegressionX.svelte
+++ b/src/lib/marks/RegressionX.svelte
@@ -3,24 +3,30 @@
 -->
 
 <script module lang="ts">
-    export type RegressionXMarkProps = RegressionMarkProps;
+    import type { ChannelAccessor } from '../types/index.js';
+    import type { RegressionMarkProps as BaseRegressionMarkProps } from './helpers/Regression.svelte';
+
+    export type RegressionXMarkProps = BaseRegressionMarkProps & {
+        data?: Record<string | symbol, any>[];
+        z?: ChannelAccessor;
+    };
 </script>
 
 <script lang="ts">
     import { resolveChannel } from '../helpers/resolve.js';
-    import type { ChannelName } from 'svelteplot/types/index.js';
+    import type { ChannelName, DataRecord } from 'svelteplot/types/index.js';
     import Mark from '../Mark.svelte';
-    import Regression, { type RegressionMarkProps } from './helpers/Regression.svelte';
+    import Regression from './helpers/Regression.svelte';
     import { groups as d3Groups } from 'd3-array';
 
-    let { data = [{}], ...options }: RegressionXMarkProps = $props();
+    let { data = [{} as DataRecord], ...options }: RegressionXMarkProps = $props();
 
     let groupBy: ChannelName | null =
         options.stroke != null ? 'stroke' : options.z != null ? 'z' : null;
     // separate groups
     let groups = $derived(
         groupBy !== null
-            ? d3Groups(data, (d) => resolveChannel(groupBy as ChannelName, d, options)).map(
+            ? d3Groups(data, (d) => resolveChannel(groupBy as ChannelName, d, options as any)).map(
                   (g) => g[1]
               )
             : [data]
@@ -29,6 +35,6 @@
 
 <Mark type="regression">
     {#each groups as group, g (g)}
-        <Regression data={group} dependent="x" {...options} />
+        <Regression data={group as any} dependent="x" {...options as any} />
     {/each}
 </Mark>

--- a/src/lib/marks/RegressionY.svelte
+++ b/src/lib/marks/RegressionY.svelte
@@ -2,24 +2,30 @@
     Calculates and displays a regression line with y as the dependent variable
 -->
 <script module lang="ts">
-    export type RegressionYMarkProps = RegressionMarkProps;
+    import type { ChannelAccessor } from '../types/index.js';
+    import type { RegressionMarkProps as BaseRegressionMarkProps } from './helpers/Regression.svelte';
+
+    export type RegressionYMarkProps = BaseRegressionMarkProps & {
+        data?: Record<string | symbol, any>[];
+        z?: ChannelAccessor;
+    };
 </script>
 
 <script lang="ts">
     import { resolveChannel } from '../helpers/resolve.js';
-    import type { ChannelName } from 'svelteplot/types/index.js';
+    import type { ChannelName, DataRecord } from 'svelteplot/types/index.js';
     import Mark from '../Mark.svelte';
-    import Regression, { type RegressionMarkProps } from './helpers/Regression.svelte';
+    import Regression from './helpers/Regression.svelte';
     import { groups as d3Groups } from 'd3-array';
 
-    let { data = [{}], ...options }: RegressionYMarkProps = $props();
+    let { data = [{} as DataRecord], ...options }: RegressionYMarkProps = $props();
 
     let groupBy: ChannelName | null =
         options.stroke != null ? 'stroke' : options.z != null ? 'z' : null;
     // separate groups
     let groups = $derived(
         groupBy !== null
-            ? d3Groups(data, (d) => resolveChannel(groupBy as ChannelName, d, options)).map(
+            ? d3Groups(data, (d) => resolveChannel(groupBy as ChannelName, d, options as any)).map(
                   (g) => g[1]
               )
             : [data]
@@ -28,6 +34,6 @@
 
 <Mark type="regression">
     {#each groups as group, i (i)}
-        <Regression data={group} dependent="y" {...options} />
+        <Regression data={group as any} dependent="y" {...options as any} />
     {/each}
 </Mark>

--- a/src/lib/marks/Spike.svelte
+++ b/src/lib/marks/Spike.svelte
@@ -44,4 +44,4 @@
     });
 </script>
 
-<Vector {data} {...options} />
+<Vector {data} {...options as any} />

--- a/src/lib/marks/Trail.svelte
+++ b/src/lib/marks/Trail.svelte
@@ -135,17 +135,18 @@
                         {@const defined = trailData.map(
                             (d) =>
                                 d.valid &&
-                                d.r >= 0 &&
+                                (d.r ?? 0) >= 0 &&
                                 (resolveProp(options.defined, d.datum, true) ?? true)
                         )}
-                        {@const pathString = trailPath(samples, defined, d3Path(), {
-                            curve,
-                            cap,
-                            tension,
-                            ...(typeof resolution === 'number'
-                                ? { samplesPerSegment: resolution }
-                                : {})
-                        })}
+                        {@const pathString =
+                            trailPath(samples, defined, d3Path(), {
+                                curve,
+                                cap,
+                                tension,
+                                ...(typeof resolution === 'number'
+                                    ? { samplesPerSegment: resolution }
+                                    : {})
+                            }) || ''}
                         {@const [style, styleClass] = resolveStyles(
                             plot,
                             trailData[0],

--- a/src/lib/marks/WaffleX.svelte
+++ b/src/lib/marks/WaffleX.svelte
@@ -53,9 +53,9 @@
 
     const {
         data = [{} as Datum],
-        class: className = null,
+        class: className = '',
         stack,
-        symbol = null,
+        symbol,
         unit,
         ...options
     }: WaffleXMarkProps = $derived({ ...DEFAULTS, ...markProps });
@@ -78,8 +78,8 @@
     requiredScales={{ y: ['band'] }}
     channels={['x1', 'x2', 'y', 'fill', 'stroke', 'opacity', 'fillOpacity', 'strokeOpacity']}
     {...args}>
-    {#snippet children({ mark, usedScales, scaledData })}
-        {@const wafflePoly = wafflePolygon('x', args, plot.scales)}
+    {#snippet children({ usedScales, scaledData })}
+        {@const wafflePoly = wafflePolygon('x', args as any, plot.scales)}
         {#each scaledData as d, i (i)}
             {@const borderRadius = resolveProp(args.borderRadius, d?.datum, 0) as BorderRadius}
             {@const hasBorderRadius =
@@ -96,7 +96,7 @@
             <g class={['waffle-x', className]}>
                 <pattern {...pattern}>
                     {#if symbol}
-                        {@render symbol({ ...rect, style, styleClass, datum: d.datum })}
+                        {@render symbol({ ...rect, style, styleClass, datum: d.datum as Datum })}
                     {:else if hasBorderRadius}
                         <path
                             d={roundedRect(rect.x, rect.y, rect.width, rect.height, borderRadius)}

--- a/src/lib/marks/WaffleY.svelte
+++ b/src/lib/marks/WaffleY.svelte
@@ -50,9 +50,9 @@
 
     const {
         data = [{} as Datum],
-        class: className = null,
+        class: className = '',
         stack,
-        symbol = null,
+        symbol,
         ...options
     }: WaffleYMarkProps = $derived({ ...DEFAULTS, ...markProps });
 
@@ -74,8 +74,8 @@
     requiredScales={{ x: ['band'] }}
     channels={['y1', 'y2', 'x', 'fill', 'stroke', 'opacity', 'fillOpacity', 'strokeOpacity']}
     {...args}>
-    {#snippet children({ mark, usedScales, scaledData })}
-        {@const wafflePoly = wafflePolygon('y', args, plot.scales)}
+    {#snippet children({ usedScales, scaledData })}
+        {@const wafflePoly = wafflePolygon('y', args as any, plot.scales)}
         {#each scaledData as d, i (i)}
             {@const [style, styleClass] = resolveStyles(
                 plot,
@@ -98,7 +98,7 @@
             <g class={['waffle-y', className]}>
                 <pattern {...pattern}>
                     {#if symbol}
-                        {@render symbol({ ...rect, style, styleClass, datum: d.datum })}
+                        {@render symbol({ ...rect, style, styleClass, datum: d.datum as Datum })}
                     {:else if hasBorderRadius}
                         <path
                             d={roundedRect(rect.x, rect.y, rect.width, rect.height, borderRadius)}

--- a/src/lib/marks/helpers/RuleCanvas.svelte
+++ b/src/lib/marks/helpers/RuleCanvas.svelte
@@ -62,21 +62,24 @@ Helper component for rendering Rule marks (RuleX and RuleY) in canvas
                 for (const datum of data) {
                     if (!datum.valid) continue;
 
-                    let { stroke, ...restStyles } = resolveScaledStyleProps(
+                    const styleProps = resolveScaledStyleProps(
                         datum.datum,
                         options,
                         usedScales,
                         plot,
                         'stroke'
+                    ) as Record<string, unknown>;
+
+                    const opacity = maybeOpacity(styleProps['opacity']);
+                    const strokeOpacity = maybeOpacity(styleProps['stroke-opacity']);
+
+                    const stroke = resolveColor(
+                        String(styleProps.stroke || 'currentColor'),
+                        canvas
                     );
 
-                    const opacity = maybeOpacity(restStyles['opacity']);
-                    const strokeOpacity = maybeOpacity(restStyles['stroke-opacity']);
-
-                    stroke = resolveColor(stroke || 'currentColor', canvas);
-
                     if (stroke && stroke !== 'none') {
-                        const resolvedLinecap = restStyles['stroke-linecap'] as
+                        const resolvedLinecap = styleProps['stroke-linecap'] as
                             | CanvasLineCap
                             | undefined
                             | null;

--- a/src/lib/marks/helpers/TrailCanvas.svelte
+++ b/src/lib/marks/helpers/TrailCanvas.svelte
@@ -4,7 +4,8 @@
         UsedScales,
         CurveName,
         ConstantAccessor,
-        DataRecord
+        DataRecord,
+        ChannelAccessor
     } from 'svelteplot/types/index.js';
     import CanvasLayer from './CanvasLayer.svelte';
     import type { Attachment } from 'svelte/attachments';
@@ -23,10 +24,8 @@
         data: ScaledDataRecord<Datum>[][];
         usedScales: UsedScales;
         options: {
-            fill?: ConstantAccessor<string, Datum>;
+            fill?: ChannelAccessor<Datum>;
             defined?: ConstantAccessor<boolean, Datum>;
-            opacity?: ConstantAccessor<number, Datum>;
-            'fill-opacity'?: ConstantAccessor<number, Datum>;
         };
     }
 
@@ -70,22 +69,22 @@
                     const defined = trailData.map(
                         (d) =>
                             d.valid &&
-                            d.r >= 0 &&
-                            (resolveProp(options.defined, d.datum, true) ?? true)
+                            (d.r ?? 0) >= 0 &&
+                            (resolveProp(options.defined as any, d.datum, true) ?? true)
                     );
 
-                    let { fill, ...restStyles } = resolveScaledStyleProps(
+                    const styleProps = resolveScaledStyleProps(
                         firstPoint.datum,
-                        options,
+                        options as any,
                         usedScales,
                         plot,
                         'fill'
-                    );
+                    ) as Record<string, unknown>;
 
-                    const opacity = maybeOpacity(restStyles['opacity']);
-                    const fillOpacity = maybeOpacity(restStyles['fill-opacity']);
+                    const opacity = maybeOpacity(styleProps['opacity']);
+                    const fillOpacity = maybeOpacity(styleProps['fill-opacity']);
 
-                    fill = resolveColor(fill, canvas);
+                    const fill = resolveColor(String(styleProps.fill || 'currentColor'), canvas);
 
                     context.fillStyle = fill ? fill : 'currentColor';
                     context.beginPath();


### PR DESCRIPTION
Resolves #471
Resolves #420 
Resolves #421 
Resolves #451 
Resolves #452 
Resolves #468 
Resolves #471 
Resolves #449  
Resolves #427 
Resolves #445

Summary
- resolve derived prop typing issues and add safe casts/guards across the Box, Custom, Image, Regression, Spike, Trail, and Waffle marks
- tighten trail/tooling helpers (RuleCanvas, TrailCanvas) to avoid undefined style values and ensure defaults are handled
- align mark inputs with expected data shapes and remove unnecessary prop spreads that caused type complaints

Testing
- Not run (not requested)