### PR TITLE
types: Fix svelte-check issues in mark helpers

### DIFF
--- a/src/lib/marks/RegressionX.svelte
+++ b/src/lib/marks/RegressionX.svelte
@@ -4,11 +4,12 @@
 
 <script module lang="ts">
     import type { ChannelAccessor } from '../types/index.js';
-    import type { RegressionMarkProps as BaseRegressionMarkProps } from './helpers/Regression.svelte';
+    import type { RegressionOptions } from './helpers/Regression.svelte';
 
-    export type RegressionXMarkProps = BaseRegressionMarkProps & {
+    export type RegressionXMarkProps = RegressionOptions & {
         data?: Record<string | symbol, any>[];
         z?: ChannelAccessor;
+        canvas?: boolean;
     };
 </script>
 

--- a/src/lib/marks/RegressionY.svelte
+++ b/src/lib/marks/RegressionY.svelte
@@ -3,11 +3,12 @@
 -->
 <script module lang="ts">
     import type { ChannelAccessor } from '../types/index.js';
-    import type { RegressionMarkProps as BaseRegressionMarkProps } from './helpers/Regression.svelte';
+    import type { RegressionOptions } from './helpers/Regression.svelte';
 
-    export type RegressionYMarkProps = BaseRegressionMarkProps & {
+    export type RegressionYMarkProps = RegressionOptions & {
         data?: Record<string | symbol, any>[];
         z?: ChannelAccessor;
+        canvas?: boolean;
     };
 </script>
 

--- a/src/lib/marks/helpers/DotCanvas.svelte
+++ b/src/lib/marks/helpers/DotCanvas.svelte
@@ -25,14 +25,15 @@
         data: ScaledDataRecord[];
     } = $props();
 
-    function drawSymbolPath(symbolType: string, size: number, context) {
+    function drawSymbolPath(symbolType: string, size: number, context: CanvasRenderingContext2D) {
         // maybeSymbol(symbolType).draw(context, size);
         return d3Symbol(maybeSymbol(symbolType), size).context(context)();
     }
 
     let _markOptions = $state(mark.options);
 
-    const renderDots: Attachment = (canvas: HTMLCanvasElement) => {
+    const renderDots: Attachment = (canvasEl: Element) => {
+        const canvas = canvasEl as HTMLCanvasElement;
         const context = canvas.getContext('2d');
 
         $effect(() => {
@@ -44,8 +45,8 @@
                     if (datum.valid) {
                         let { fill, stroke } = datum;
 
-                        fill = resolveColor(fill, canvas);
-                        stroke = resolveColor(stroke, canvas);
+                        fill = resolveColor(fill ?? 'none', canvas) as string;
+                        stroke = resolveColor(stroke ?? 'none', canvas) as string;
 
                         if (stroke && stroke !== 'none') {
                             const strokeWidth = resolveProp(
@@ -53,17 +54,18 @@
                                 datum.datum,
                                 1.6
                             );
-                            context.lineWidth = strokeWidth;
+                            context.lineWidth = strokeWidth ?? 1.6;
                         }
 
                         context.fillStyle = fill ? fill : 'none';
                         context.strokeStyle = stroke ? stroke : 'none';
-                        context.translate(datum.x, datum.y);
+                        context.translate(datum.x ?? 0, datum.y ?? 0);
 
-                        const size = datum.r * datum.r * Math.PI;
+                        const r = datum.r ?? 1;
+                        const size = r * r * Math.PI;
 
                         context.beginPath();
-                        drawSymbolPath(datum.symbol, size, context);
+                        drawSymbolPath(datum.symbol ?? 'circle', size, context);
                         context.closePath();
 
                         const { opacity = 1, fillOpacity = 1, strokeOpacity = 1 } = datum;
@@ -74,7 +76,7 @@
                         if (strokeOpacity != null)
                             context.globalAlpha = (opacity ?? 1) * strokeOpacity;
                         if (stroke && stroke !== 'none') context.stroke();
-                        context.translate(-datum.x, -datum.y);
+                        context.translate(-(datum.x ?? 0), -(datum.y ?? 0));
                     }
                 }
             }

--- a/src/lib/marks/helpers/GeoCanvas.svelte
+++ b/src/lib/marks/helpers/GeoCanvas.svelte
@@ -28,11 +28,12 @@
 
     const plot = usePlot();
 
-    function maybeOpacity(value) {
+    function maybeOpacity(value: unknown) {
         return value == null ? 1 : +value;
     }
 
-    const render: Attachment = (canvas: HTMLCanvasElement) => {
+    const render: Attachment = (canvasEl: Element) => {
+        const canvas = canvasEl as HTMLCanvasElement;
         const context = canvas.getContext('2d');
 
         $effect(() => {
@@ -44,7 +45,7 @@
 
                 for (const d of data) {
                     if (!d.valid) continue;
-                    const geometry = resolveProp(mark.options.geometry, d.datum, d.datum);
+                    const geometry = resolveProp((mark.options as any).geometry, d.datum, d.datum);
                     // untrack the filter test to avoid redrawing when not necessary
                     let { stroke, fill, ...restStyles } = resolveScaledStyleProps(
                         d.datum,
@@ -52,7 +53,7 @@
                         usedScales,
                         plot,
                         GEOJSON_PREFER_STROKE.has(geometry.type) ? 'stroke' : 'fill'
-                    );
+                    ) as { fill: string; stroke: string } & Record<string, unknown>;
 
                     const opacity = maybeOpacity(restStyles['opacity']);
                     const fillOpacity = maybeOpacity(restStyles['fill-opacity']);
@@ -62,13 +63,13 @@
                         fill =
                             currentColor ||
                             (currentColor = getComputedStyle(
-                                canvas?.parentElement?.parentElement
+                                canvas?.parentElement?.parentElement ?? canvas
                             ).getPropertyValue('color'));
                     if (`${stroke}`.toLowerCase() === 'currentcolor')
                         stroke =
                             currentColor ||
                             (currentColor = getComputedStyle(
-                                canvas?.parentElement?.parentElement
+                                canvas?.parentElement?.parentElement ?? canvas
                             ).getPropertyValue('color'));
                     if (CSS_VAR.test(fill))
                         fill = getComputedStyle(canvas).getPropertyValue(fill.slice(4, -1));

--- a/src/lib/marks/helpers/LineCanvas.svelte
+++ b/src/lib/marks/helpers/LineCanvas.svelte
@@ -56,7 +56,7 @@
                         usedScales,
                         plot,
                         'stroke'
-                    );
+                    ) as { fill: string; stroke: string } & Record<string, unknown>;
 
                     const opacity = maybeOpacity(restStyles['opacity']);
                     const strokeOpacity = maybeOpacity(restStyles['stroke-opacity']);
@@ -67,12 +67,12 @@
                         1.4
                     ) as number;
 
-                    if (mark.options.outlineStroke) {
+                    const lineOpts = mark.options as any;
+                    if (lineOpts.outlineStroke) {
                         // draw stroke outline first
-                        const outlineStroke = resolveColor(mark.options.outlineStroke, canvas);
-                        const outlineStrokeWidth =
-                            mark.options.outlineStrokeWidth ?? strokeWidth + 2;
-                        const outlineStrokeOpacity = mark.options.outlineStrokeOpacity ?? 1;
+                        const outlineStroke = resolveColor(lineOpts.outlineStroke, canvas);
+                        const outlineStrokeWidth = lineOpts.outlineStrokeWidth ?? strokeWidth + 2;
+                        const outlineStrokeOpacity = lineOpts.outlineStrokeOpacity ?? 1;
 
                         context.lineWidth = outlineStrokeWidth;
                         context.strokeStyle = outlineStroke;
@@ -82,7 +82,7 @@
                         context.stroke();
                     }
 
-                    stroke = resolveColor(stroke, canvas);
+                    stroke = resolveColor(stroke, canvas) as string;
 
                     if (stroke && stroke !== 'none') {
                         context.lineWidth = strokeWidth ?? 1.4;

--- a/src/lib/marks/helpers/RectCanvas.svelte
+++ b/src/lib/marks/helpers/RectCanvas.svelte
@@ -70,7 +70,8 @@ Helper class for rendering Cell, Bar and Rect marks in canvas
         return value == null ? 1 : +value;
     }
 
-    const render: Attachment = (canvas: HTMLCanvasElement) => {
+    const render: Attachment = (canvasEl: Element) => {
+        const canvas = canvasEl as HTMLCanvasElement;
         const context = canvas.getContext('2d');
 
         $effect(() => {
@@ -93,27 +94,31 @@ Helper class for rendering Cell, Bar and Rect marks in canvas
                     const miny = Math.min(y1, y2);
                     const maxy = Math.max(y1, y2);
 
-                    const inset = +resolveProp(options.inset, datum.datum, 0);
-                    const insetLeft = +resolveProp(
-                        options.insetLeft,
-                        datum.datum,
-                        useInsetAsFallbackHorizontally ? inset : 0
-                    );
-                    const insetRight = +resolveProp(
-                        options.insetRight,
-                        datum.datum,
-                        useInsetAsFallbackHorizontally ? inset : 0
-                    );
-                    const insetTop = +resolveProp(
-                        options.insetTop,
-                        datum.datum,
-                        useInsetAsFallbackVertically ? inset : 0
-                    );
-                    const insetBottom = +resolveProp(
-                        options.insetBottom,
-                        datum.datum,
-                        useInsetAsFallbackVertically ? inset : 0
-                    );
+                    const inset = resolveProp(options.inset, datum.datum, 0) ?? 0;
+                    const insetLeft =
+                        resolveProp(
+                            options.insetLeft,
+                            datum.datum,
+                            useInsetAsFallbackHorizontally ? inset : 0
+                        ) ?? 0;
+                    const insetRight =
+                        resolveProp(
+                            options.insetRight,
+                            datum.datum,
+                            useInsetAsFallbackHorizontally ? inset : 0
+                        ) ?? 0;
+                    const insetTop =
+                        resolveProp(
+                            options.insetTop,
+                            datum.datum,
+                            useInsetAsFallbackVertically ? inset : 0
+                        ) ?? 0;
+                    const insetBottom =
+                        resolveProp(
+                            options.insetBottom,
+                            datum.datum,
+                            useInsetAsFallbackVertically ? inset : 0
+                        ) ?? 0;
 
                     const rectX = minx + insetLeft;
                     const rectY = miny + insetBottom;
@@ -135,17 +140,17 @@ Helper class for rendering Cell, Bar and Rect marks in canvas
                         usedScales,
                         plot,
                         defaultColorProp
-                    );
+                    ) as { fill: string; stroke: string } & Record<string, unknown>;
 
                     const opacity = maybeOpacity(restStyles['opacity']);
                     const fillOpacity = maybeOpacity(restStyles['fill-opacity']);
                     const strokeOpacity = maybeOpacity(restStyles['stroke-opacity']);
 
                     if (typeof fill === 'string') {
-                        fill = resolveColor(fill, canvas);
+                        fill = resolveColor(fill, canvas) as string;
                     }
                     if (typeof stroke === 'string') {
-                        stroke = resolveColor(stroke, canvas);
+                        stroke = resolveColor(stroke, canvas) as string;
                     }
 
                     if (stroke && stroke !== 'none') {

--- a/src/lib/marks/helpers/Regression.svelte
+++ b/src/lib/marks/helpers/Regression.svelte
@@ -1,15 +1,15 @@
 <script module lang="ts">
-    import type { BaseMarkProps, ChannelAccessor, FacetContext } from '../../types/index.js';
+    import type { BaseMarkProps, ChannelAccessor } from '../../types/index.js';
 
-    type RegressionType = 'linear' | 'quad' | 'poly' | 'exp' | 'log' | 'pow' | 'loess';
+    export type RegressionType = 'linear' | 'quad' | 'poly' | 'exp' | 'log' | 'pow' | 'loess';
 
-    export type RegressionMarkProps = BaseMarkProps & {
+    export type RegressionOptions = BaseMarkProps & {
         /** the horizontal position channel; bound to the x scale */
         x: ChannelAccessor;
         /** the vertical position channel; bound to the y scale */
         y: ChannelAccessor;
         /** the regression model type */
-        type: RegressionType;
+        type?: RegressionType;
         /**
          * If order is specified, sets the regression's order to the specified number.
          * For example, if order is set to 4, the regression generator will perform a
@@ -19,13 +19,13 @@
          * regression line will fit your data with a high determination coefficient,
          * it may have little predictive power for data outside of your domain.
          */
-        order: number;
+        order?: number;
         /** the base for logarithmic regression */
-        base: number;
+        base?: number;
         /** the bandwidth for LOESS regression, as a fraction of the data range (0 to 1) */
-        span: number;
+        span?: number;
         /** the confidence level for confidence bands (e.g. 0.95 for 95% confidence) */
-        confidence: number;
+        confidence?: number | false;
     };
 </script>
 
@@ -45,25 +45,64 @@
     import { resolveChannel } from '../../helpers/resolve.js';
     import { confidenceInterval } from '../../helpers/math.js';
     import callWithProps from '../../helpers/callWithProps.js';
-    import { isDate } from '../../helpers/typeChecks.js';
+    import type { DataRecord, FacetContext, RawValue } from 'svelteplot/types/index.js';
+    import { usePlot } from 'svelteplot/hooks/usePlot.svelte.js';
 
-    const regressions = new Map<RegressionType, typeof regressionLinear>([
-        ['linear', regressionLinear],
-        ['quad', regressionQuad],
-        ['poly', regressionPoly],
-        ['exp', regressionExp],
-        ['log', regressionLog],
-        ['pow', regressionPow],
-        ['loess', regressionLoess]
-    ]);
+    type RegressionData = { x: number; y: number };
+    type RegressionOutput = [number, number][] & {
+        predict?: (x: number) => number;
+        predictMany?: (points: number[]) => number[];
+    };
+    type RegressionGenerator = ((data: RegressionData[]) => RegressionOutput) & {
+        x: (fn: (d: RegressionData) => number) => RegressionGenerator;
+        y: (fn: (d: RegressionData) => number) => RegressionGenerator;
+        domain?: (domain: [number, number]) => RegressionGenerator;
+        order?: (order: number) => RegressionGenerator;
+        base?: (base: number) => RegressionGenerator;
+        bandwidth?: (span: number) => RegressionGenerator;
+    };
+    type RegressionFactory = () => RegressionGenerator;
 
-    function maybeRegression(name: string) {
-        name = `${name}`.toLowerCase();
-        if (regressions.has(name)) return regressions.get(name);
-        throw new Error('unknown regression ' + name);
+    interface RegressionProps extends RegressionOptions {
+        data: DataRecord[];
+        dependent: 'x' | 'y';
+        canvas?: boolean;
     }
 
-    import { usePlot } from 'svelteplot/hooks/usePlot.svelte.js';
+    // Normalize all regression constructors behind one callable adapter shape.
+    const regressions: Record<RegressionType, RegressionFactory> = {
+        linear: regressionLinear as RegressionFactory,
+        quad: regressionQuad as RegressionFactory,
+        poly: regressionPoly as RegressionFactory,
+        exp: regressionExp as RegressionFactory,
+        log: regressionLog as RegressionFactory,
+        pow: regressionPow as RegressionFactory,
+        loess: regressionLoess as RegressionFactory
+    };
+
+    function maybeRegression(name: RegressionType): RegressionFactory {
+        const fn = regressions[name];
+        if (fn) return fn;
+        throw new Error(`unknown regression ${name}`);
+    }
+
+    // Regression engines operate on numeric domains; convert Date channels to epoch ms.
+    function toNumeric(value: RawValue): number {
+        return value instanceof Date ? value.valueOf() : Number(value);
+    }
+
+    // Convert generated points back to Date for time scales so downstream marks render correctly.
+    function toOutputX(value: number, scaleType: string): RawValue {
+        return scaleType === 'time' ? new Date(value) : value;
+    }
+
+    function makeTicks(domain: [number, number], count = 40): number[] {
+        const [start, end] = domain;
+        if (start === end) return [start];
+        const tickCount = Math.max(1, count);
+        const step = (end - start) / tickCount;
+        return Array.from({ length: tickCount + 1 }, (_, i) => start + i * step);
+    }
 
     const plot = usePlot();
 
@@ -72,91 +111,138 @@
         dependent,
         type = 'linear',
         order = 3,
-        base = 2.71828,
+        base = Math.E,
         span = 0.3,
         confidence = 0.99,
-        class: className = null,
+        class: className = '',
+        canvas = false,
         ...options
-    }: RegressionMarkProps & { dependent: 'x' | 'y' } = $props();
+    }: RegressionProps = $props();
 
     const { getTestFacet } = getContext<FacetContext>('svelteplot/facet');
-    let testFacet = $derived(getTestFacet());
+    const testFacet = $derived(getTestFacet());
 
-    let filteredData = $derived(data.filter((d) => testFacet(d, options)));
+    const filteredData = $derived(data.filter((d) => testFacet(d, options as any)));
 
-    let independent: 'x' | 'y' = $derived(dependent === 'x' ? 'y' : 'x');
+    const independent: 'x' | 'y' = $derived(dependent === 'x' ? 'y' : 'x');
 
-    let regressionFn = $derived(maybeRegression(type));
+    const regressionFn = $derived(maybeRegression(type));
 
-    let regression = $derived(
+    // Build a clean numeric input set for regression fitting, dropping invalid rows early.
+    const regressionInput = $derived(
+        filteredData
+            .map((d) => ({
+                x: toNumeric(resolveChannel(independent, d, options as any)),
+                y: toNumeric(resolveChannel(dependent, d, options as any))
+            }))
+            .filter(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))
+    );
+
+    const independentDomain = $derived.by(() => {
+        // Prefer the active scale domain, but fall back to observed data when the scale
+        // is still initializing (common in tests and first render passes).
+        const scaleDomain = plot.scales[independent].domain;
+        const scaleStart = toNumeric(scaleDomain[0]);
+        const scaleEnd = toNumeric(scaleDomain.at(-1) ?? scaleDomain[0]);
+        if (Number.isFinite(scaleStart) && Number.isFinite(scaleEnd)) {
+            return scaleStart <= scaleEnd
+                ? ([scaleStart, scaleEnd] as [number, number])
+                : ([scaleEnd, scaleStart] as [number, number]);
+        }
+        if (regressionInput.length === 0) return null;
+        let min = Infinity;
+        let max = -Infinity;
+        for (const point of regressionInput) {
+            if (point.x < min) min = point.x;
+            if (point.x > max) max = point.x;
+        }
+        if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+        return min <= max ? ([min, max] as [number, number]) : ([max, min] as [number, number]);
+    });
+
+    const regression = $derived(
         callWithProps(regressionFn, [], {
-            x: (d) => resolveChannel(independent, d, options),
-            y: (d) => resolveChannel(dependent, d, options),
+            x: (d: RegressionData) => d.x,
+            y: (d: RegressionData) => d.y,
             ...(type === 'poly' ? { order } : {}),
             ...(type === 'log' ? { base } : {}),
-            ...(!type.startsWith('loess') ? { domain: plot.scales[independent].domain } : {}),
+            ...(type !== 'loess' && independentDomain != null ? { domain: independentDomain } : {}),
             ...(type === 'loess' ? { bandwidth: span } : {})
-        })(filteredData)
+        })(regressionInput)
     );
 
-    let regrPoints = $derived([
-        ...new Set([
-            plot.scales[independent].domain[0],
-            ...plot.scales[independent].fn.ticks(40),
-            plot.scales[independent].domain[1]
-        ])
-    ]);
+    const regrPoints = $derived.by(() => {
+        if (independentDomain == null) return [] as number[];
+        // Use scale ticks when available; otherwise synthesize evenly spaced samples.
+        const ticks = plot.scales[independent].fn
+            .ticks(40)
+            .map(toNumeric)
+            .filter((value): value is number => Number.isFinite(value));
+        const points = ticks.length > 0 ? ticks : makeTicks(independentDomain, 40);
+        return [
+            ...new Set(
+                [independentDomain[0], ...points, independentDomain[1]].filter(
+                    (value): value is number => Number.isFinite(value)
+                )
+            )
+        ].sort((a, b) => a - b);
+    });
 
-    let regrData = $derived(
-        regression.predictMany
-            ? regression.predictMany(regrPoints).map((__y, i) => ({ __x: regrPoints[i], __y }))
-            : regression.predict
-              ? regrPoints.map((__x) => {
-                    // const __x = x;
-                    const __y = regression.predict(__x);
-                    return { __x, __y };
-                })
-              : regression.map(([__x, __y]) => ({
-                    __x: plot.scales[independent].type === 'time' ? new Date(__x) : __x,
-                    __y
-                }))
-    );
+    const regrData = $derived.by(() => {
+        // Prefer batch prediction when supported, then per-point predict, then raw curve output.
+        if (typeof regression.predictMany === 'function') {
+            return regression.predictMany(regrPoints).map((__y, i) => ({
+                __x: toOutputX(regrPoints[i], plot.scales[independent].type),
+                __y
+            }));
+        }
+        if (typeof regression.predict === 'function') {
+            return regrPoints.map((point) => ({
+                __x: toOutputX(point, plot.scales[independent].type),
+                __y: regression.predict!(point)
+            }));
+        }
+        return regression.map(([__x, __y]) => ({
+            __x: toOutputX(__x, plot.scales[independent].type),
+            __y
+        }));
+    });
 
-    let stroke = $derived(
-        options.stroke != null ? resolveChannel('stroke', filteredData[0], options) : null
-    );
-
-    let confBandGen = $derived(
-        confidence !== false && regression.predict
-            ? confidenceInterval(
-                  data
-                      .map((d) => ({
-                          x: resolveChannel(independent, d, options),
-                          y: resolveChannel(dependent, d, options)
-                      }))
-                      .filter(
-                          ({ x, y }) => (Number.isFinite(x) || isDate(x)) && Number.isFinite(y)
-                      ),
-                  regression.predict,
-                  1 - confidence
-              )
+    const stroke = $derived(
+        options.stroke != null && filteredData.length
+            ? resolveChannel('stroke', filteredData[0], options as any)
             : null
     );
 
-    let confBandData = $derived(
-        confidence !== false && regression.predict
-            ? regrPoints.map((x) => {
-                  const { x: __x, left, right } = confBandGen(x);
-                  return { __x, __y1: left, __y2: right };
-              })
-            : []
+    const confBandGen = $derived(
+        // Confidence bands require a predictor function and at least 3 points.
+        confidence !== false &&
+            typeof confidence === 'number' &&
+            typeof regression.predict === 'function' &&
+            regressionInput.length > 2
+            ? confidenceInterval(regressionInput, regression.predict, 1 - confidence)
+            : null
     );
+
+    const confBandData = $derived.by(() => {
+        if (confBandGen == null) return [];
+        return regrPoints.map((x) => {
+            const { x: __x, left, right } = confBandGen(x);
+            return {
+                __x: toOutputX(__x, plot.scales[independent].type),
+                __y1: left,
+                __y2: right
+            };
+        });
+    });
 </script>
 
 {#if filteredData.length}
+    <!-- TODO: when canvas rendering is requested, render both marks in same <canvas> -->
     <g class="regression-{independent} {className || ''}">
         <Line
             data={regrData}
+            {canvas}
             {...{
                 ...options,
                 fx: null,
@@ -168,6 +254,7 @@
         {#if confBandData.length}
             <Area
                 data={confBandData}
+                {canvas}
                 {...dependent === 'y'
                     ? { x1: '__x', y1: '__y1', y2: '__y2' }
                     : { y1: '__x', x1: '__y1', x2: '__y2' }}

--- a/src/lib/marks/helpers/TextCanvas.svelte
+++ b/src/lib/marks/helpers/TextCanvas.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" generics="Datum = DataRecord | GeoJSON.GeoJsonObject">
-    interface TextCanvasProps<Datum extends DataRecord<object>> {
+    interface TextCanvasProps<Datum> {
         data: ScaledDataRecord<Datum>[];
         options: BaseMarkProps<Datum> & {
             x?: ChannelAccessor<Datum>;
@@ -164,7 +164,11 @@
                 for (const datum of data) {
                     if (!datum.valid) continue;
 
-                    const frameAnchor = resolveProp(options.frameAnchor, datum.datum, 'middle');
+                    const frameAnchor = resolveProp(
+                        options.frameAnchor,
+                        datum.datum as any,
+                        'middle'
+                    );
                     const isLeft =
                         frameAnchor === 'left' ||
                         frameAnchor === 'top-left' ||
@@ -206,7 +210,7 @@
                     const lineAnchor = normalizeLineAnchor(
                         resolveProp(
                             options.lineAnchor,
-                            datum.datum,
+                            datum.datum as any,
                             options.y != null
                                 ? 'middle'
                                 : isTop
@@ -218,7 +222,7 @@
                     );
                     const defaultTextAnchor = isLeft ? 'start' : isRight ? 'end' : 'middle';
                     const styleProps = resolveScaledStyleProps(
-                        datum.datum,
+                        datum.datum as any,
                         {
                             ...DEFAULT_TEXT_OPTIONS,
                             textAnchor: defaultTextAnchor,
@@ -227,7 +231,7 @@
                         usedScales,
                         plot,
                         'fill'
-                    );
+                    ) as Record<string, unknown>;
 
                     const inheritedFontSize = inheritedFontStyles.fontSize || '12px';
                     const { css: fontSize, numeric: fontSizePx } = toFontSize(
@@ -259,7 +263,7 @@
                             Math.PI) /
                         180;
 
-                    const textLines = String(resolveProp(options.text, datum.datum, ''))
+                    const textLines = String(resolveProp(options.text, datum.datum as any, ''))
                         .split('\n')
                         .map((line) => textTransform(line, textTransformValue));
 

--- a/src/routes/examples/regression/cars.svelte
+++ b/src/routes/examples/regression/cars.svelte
@@ -9,11 +9,24 @@
 
     let { cars } = $props();
 
-    let type = $state('linear');
+    type RegressionKind =
+        | 'linear'
+        | 'quad'
+        | 'exp'
+        | 'log'
+        | 'pow';
+    const types: RegressionKind[] = [
+        'linear',
+        'quad',
+        'exp',
+        'log',
+        'pow'
+    ];
+
+    let type = $state<RegressionKind>('linear');
     let order = $state(3);
     let span = $state(0.7);
     let confidence = $state(0.99);
-    const types = ['linear', 'quad', 'exp', 'log', 'pow'];
 </script>
 
 <Select label="Type" bind:value={type} options={types} />

--- a/src/tests/regressionX.test.svelte.ts
+++ b/src/tests/regressionX.test.svelte.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
-// @ts-expect-error - Svelte component has no typed default export
+// @ts-ignore - tsc in lint:types does not see default export for .svelte test component
 import RegressionXTest from './regressionX.test.svelte';
 
 const linearData = [

--- a/src/tests/regressionY.test.svelte.ts
+++ b/src/tests/regressionY.test.svelte.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
-// @ts-expect-error - Svelte component has no typed default export
+// @ts-ignore - tsc in lint:types does not see default export for .svelte test component
 import RegressionYTest from './regressionY.test.svelte';
 
 const linearData = [


### PR DESCRIPTION
Resolves #467
Resolves #457 
Resolves #458
Resolves #459 
Resolves #460 
Resolves #464 
Resolves #465 
Resolves #469 

This pull request focuses on improving type safety and robustness across several mark helper components, especially for canvas rendering and box plot handling. The changes mainly address stricter typing, better handling of optional and default values, and more reliable property resolution. These updates help prevent runtime errors and make the codebase easier to maintain.

### Type Safety and Robustness Improvements

* Updated mark prop types in `RegressionX.svelte` and `RegressionY.svelte` to use `RegressionOptions`, adding a new `canvas` property for flexibility in rendering. [[1]](diffhunk://#diff-aa66f6a10cfbac67bed05425f88184c5dde6f016a5f6e6731d0be349e6ecf701L7-R12) [[2]](diffhunk://#diff-e20773c654337995e260c262392d82f7d9e81c163de5015c2ba86da7bbc6eba8L6-R11)
* Refined type handling in `Box.svelte` by enforcing array types for `data`, adding explicit type casts in data processing, and improving sorting and channel resolution logic for box plot calculations. [[1]](diffhunk://#diff-c953372a87f0576534dfbde532c83016f043df6cf89fb130c53ad209e164a3e9L50-R50) [[2]](diffhunk://#diff-c953372a87f0576534dfbde532c83016f043df6cf89fb130c53ad209e164a3e9L92-R92) [[3]](diffhunk://#diff-c953372a87f0576534dfbde532c83016f043df6cf89fb130c53ad209e164a3e9L115-R121) [[4]](diffhunk://#diff-c953372a87f0576534dfbde532c83016f043df6cf89fb130c53ad209e164a3e9L131-R137) [[5]](diffhunk://#diff-c953372a87f0576534dfbde532c83016f043df6cf89fb130c53ad209e164a3e9L144-R151) [[6]](diffhunk://#diff-c953372a87f0576534dfbde532c83016f043df6cf89fb130c53ad209e164a3e9L157-R181) [[7]](diffhunk://#diff-c953372a87f0576534dfbde532c83016f043df6cf89fb130c53ad209e164a3e9L203-R210) [[8]](diffhunk://#diff-c953372a87f0576534dfbde532c83016f043df6cf89fb130c53ad209e164a3e9L252-R270)
* Enhanced type annotations and default value handling in canvas mark helpers (`DotCanvas.svelte`, `GeoCanvas.svelte`, `LineCanvas.svelte`) to ensure correct property resolution, safer color and opacity handling, and more robust rendering logic. [[1]](diffhunk://#diff-d4124ca463e6ce5181849344b42b404cbf54725d84095505f6608db00ebed329L28-R36) [[2]](diffhunk://#diff-d4124ca463e6ce5181849344b42b404cbf54725d84095505f6608db00ebed329L47-R68) [[3]](diffhunk://#diff-d4124ca463e6ce5181849344b42b404cbf54725d84095505f6608db00ebed329L77-R79) [[4]](diffhunk://#diff-d0d75970efce1e353bb864812bc4f939ba4ce2f56c3204bbecd38a93155ba241L31-R36) [[5]](diffhunk://#diff-d0d75970efce1e353bb864812bc4f939ba4ce2f56c3204bbecd38a93155ba241L47-R56) [[6]](diffhunk://#diff-d0d75970efce1e353bb864812bc4f939ba4ce2f56c3204bbecd38a93155ba241L65-R72) [[7]](diffhunk://#diff-c3efa320f48f2a299a52e76f7e1a13fce6a0dc1d4932edc3585785acd3a9eb6dL59-R59) [[8]](diffhunk://#diff-c3efa320f48f2a299a52e76f7e1a13fce6a0dc1d4932edc3585785acd3a9eb6dL70-R75) [[9]](diffhunk://#diff-c3efa320f48f2a299a52e76f7e1a13fce6a0dc1d4932edc3585785acd3a9eb6dL85-R85)

### Marker and Multiline Text Improvements

* Improved `MarkerPath.svelte` by adding support for reversed paths, handling optional and default values for marker properties, and ensuring correct rendering of markers and invisible paths for mouse access. [[1]](diffhunk://#diff-07a80a0dd5e0ee05e459a68e6f99c8618f2d8482a8328cf897561ddc0c36f7daR50) [[2]](diffhunk://#diff-07a80a0dd5e0ee05e459a68e6f99c8618f2d8482a8328cf897561ddc0c36f7daL72-R73) [[3]](diffhunk://#diff-07a80a0dd5e0ee05e459a68e6f99c8618f2d8482a8328cf897561ddc0c36f7daL89-R97) [[4]](diffhunk://#diff-07a80a0dd5e0ee05e459a68e6f99c8618f2d8482a8328cf897561ddc0c36f7daL108-R118) [[5]](diffhunk://#diff-07a80a0dd5e0ee05e459a68e6f99c8618f2d8482a8328cf897561ddc0c36f7daL124-R127)
* Fixed type import and default value resolution in `MultilineText.svelte` for more reliable text alignment and style handling. [[1]](diffhunk://#diff-48009403a5bffe0c925498b0d9e4ed4daca8719895e5b077a238e26de616ae30L4-R4) [[2]](diffhunk://#diff-48009403a5bffe0c925498b0d9e4ed4daca8719895e5b077a238e26de616ae30L49-R49)