### PR TITLE
types: fix issues in lib/core and Mark + Plot

### DIFF
--- a/src/lib/core/FacetAxes.svelte
+++ b/src/lib/core/FacetAxes.svelte
@@ -23,13 +23,13 @@
     const facetXScale = $derived(
         scaleBand()
             .paddingInner(plot.options.fx?.paddingInner ?? plot.options.fx?.padding ?? 0.1)
-            .domain(fxValues)
+            .domain(fxValues as string[])
             .rangeRound([0, plot.plotWidth])
     );
     const facetYScale = $derived(
         scaleBand()
             .paddingInner(plot.options.fy?.paddingInner ?? plot.options.fy?.padding ?? 0.1)
-            .domain(fyValues)
+            .domain(fyValues as string[])
             .rangeRound([0, plot.plotHeight])
     );
 </script>
@@ -39,17 +39,20 @@
     <g transform="translate({plot.options.marginLeft}, 0)">
         <BaseAxisX
             class="facet-axis-x"
-            scaleFn={facetXScale}
+            scaleFn={facetXScale as any}
             scaleType="band"
             ticks={fxValues}
-            tickFormat={plot.options.fx.tickFormat || ((d) => d)}
+            tickFormat={(plot.options.fx.tickFormat || ((d: any) => d)) as any}
             tickFontSize={11}
             tickSize={0}
             tickPadding={plot.options.x.axis === plot.options.fx.axis ||
             plot.options.x.axis === 'both'
                 ? 25
                 : 5}
-            anchor={plot.options.fx.axis}
+            anchor={plot.options.fx.axis === 'both'
+                ? 'top'
+                : (plot.options.fx.axis as 'top' | 'bottom' | undefined)}
+            title={null}
             options={plot.options.fx.axisOptions || {}}
             {...plot.options.fx.axisProps || {}}
             height={plot.plotHeight}
@@ -61,14 +64,16 @@
     <g transform="translate(0, {plot.options.marginTop})">
         <BaseAxisY
             class="facet-axis-y"
-            scaleFn={facetYScale}
+            scaleFn={facetYScale as any}
             scaleType="band"
             ticks={fyValues}
-            tickFormat={plot.options.fy.tickFormat || ((d) => d)}
+            tickFormat={(plot.options.fy.tickFormat || ((d: any) => d)) as any}
             tickFontSize={11}
             tickSize={0}
             tickPadding={5}
-            anchor={plot.options.fy.axis}
+            anchor={plot.options.fy.axis === 'both'
+                ? 'right'
+                : (plot.options.fy.axis as 'left' | 'right' | undefined)}
             lineAnchor="center"
             options={plot.options.fy.axisOptions || {}}
             {...plot.options.fy.axisProps || {}}

--- a/src/lib/core/FacetGrid.svelte
+++ b/src/lib/core/FacetGrid.svelte
@@ -43,7 +43,7 @@
                     ? (plot.options.fx?.paddingInner ?? plot.options.fx?.padding ?? 0.1)
                     : 0
             )
-            .domain(fxValues)
+            .domain(fxValues as string[])
             .rangeRound([0, plot.plotWidth])
     );
     const facetYScale = $derived(
@@ -54,7 +54,7 @@
                     ? (plot.options.fy?.paddingInner ?? plot.options.fy?.padding ?? 0.1)
                     : 0
             )
-            .domain(fyValues)
+            .domain(fyValues as string[])
             .rangeRound([0, plot.plotHeight])
     );
 
@@ -75,8 +75,8 @@
             data-facet={i * fyValues.length + j}
             fill="currentColor"
             style:display={emptyFacets.get(facetX)?.get(facetY) ? 'none' : 'block'}
-            transform="translate({useFacetX ? facetXScale(facetX) : 0}, {useFacetY
-                ? facetYScale(facetY)
+            transform="translate({useFacetX ? facetXScale(facetX as string) : 0}, {useFacetY
+                ? facetYScale(facetY as string)
                 : 0})">
             <!-- facets need invisible rect -->
             <rect

--- a/src/lib/core/Plot.svelte
+++ b/src/lib/core/Plot.svelte
@@ -94,8 +94,8 @@
         axisY: {
             anchor: 'left',
             implicit: true,
-            ...USER_DEFAULTS.axis,
-            ...USER_DEFAULTS.axisY
+            ...(USER_DEFAULTS.axis as any),
+            ...(USER_DEFAULTS.axisY as any)
         },
         gridX: {
             implicit: false,
@@ -107,7 +107,7 @@
             ...asGridDefaults(USER_DEFAULTS.grid),
             ...asGridDefaults(USER_DEFAULTS.gridY)
         }
-    };
+    } as PlotDefaults;
 
     let {
         header,
@@ -171,7 +171,7 @@
     );
 
     const explicitDomains = $derived(
-        new Set(SCALES.filter((scale) => !!initialOptions[scale]?.domain))
+        new Set(SCALES.filter((scale) => !!(initialOptions as any)[scale]?.domain))
     );
 
     // one-dimensional plots have different automatic margins and heights
@@ -184,7 +184,7 @@
             explicitScales,
             explicitDomains,
             hasProjection: !!initialOptions.projection,
-            margin: initialOptions.margin,
+            margin: initialOptions.margin as number | 'auto' | undefined,
             inset: initialOptions.inset
         })
     );
@@ -217,7 +217,7 @@
 
     const defaultPointScaleHeight = $derived(
         explicitScales.has('r') && plotOptions.r.range
-            ? plotOptions.r.range[1] * 2
+            ? (plotOptions.r.range[1] as number) * 2
             : DEFAULTS.pointScaleHeight
     );
 
@@ -233,8 +233,8 @@
             ? plotOptions.height(plotWidth)
             : maybeNumber(plotOptions.height) === null || plotOptions.height === 'auto'
               ? Math.round(
-                    preScales.projection && preScales.projection.aspectRatio
-                        ? ((plotWidth * preScales.projection.aspectRatio) / xFacetCount) *
+                    preScales.projection && (preScales.projection as any).aspectRatio
+                        ? ((plotWidth * (preScales.projection as any).aspectRatio) / xFacetCount) *
                               yFacetCount +
                               plotOptions.marginTop +
                               plotOptions.marginBottom
@@ -260,7 +260,7 @@
               : maybeNumber(plotOptions.height)
     );
 
-    const plotHeight = $derived(height - plotOptions.marginTop - plotOptions.marginBottom);
+    const plotHeight = $derived((height ?? 0) - plotOptions.marginTop - plotOptions.marginBottom);
 
     // TODO: check if there's still a reason to store and expose the plot body element
     let plotBody: HTMLDivElement | null = $state(null);
@@ -280,7 +280,7 @@
         const scales = computeScales(
             plotOptions,
             facetWidth || width,
-            facetHeight || height,
+            facetHeight ?? height ?? 0,
             hasFilledDotMarks,
             marks,
             DEFAULTS
@@ -293,9 +293,9 @@
         return {
             options: plotOptions,
             width,
-            height,
-            facetWidth,
-            facetHeight,
+            height: height ?? 0,
+            facetWidth: facetWidth ?? undefined,
+            facetHeight: facetHeight ?? undefined,
             plotHeight,
             plotWidth,
             scales,
@@ -303,7 +303,7 @@
             hasFilledDotMarks,
             body: plotBody,
             css
-        };
+        } as any;
     }
 
     setContext('svelteplot', {
@@ -363,11 +363,11 @@
         const xDomainExtent =
             x.type === 'band' || x.type === 'point'
                 ? x.domain.length
-                : Math.abs(x.domain[1] - x.domain[0]);
+                : Math.abs((x.domain[1] as number) - (x.domain[0] as number));
         const yDomainExtent =
             y.type === 'band' || y.type === 'point'
                 ? y.domain.length
-                : Math.abs(y.domain[1] - y.domain[0]);
+                : Math.abs((y.domain[1] as number) - (y.domain[0] as number));
         return (
             ((plotWidth / xDomainExtent) * yDomainExtent) / aspectRatio + marginTop + marginBottom
         );
@@ -378,10 +378,10 @@
         opts: PlotOptionsParameters
     ): ResolvedPlotOptions {
         return mergeDeep<PlotOptions>(
-            {},
-            { sortOrdinalDomains: DEFAULTS.sortOrdinalDomains },
-            smartDefaultPlotOptions(opts),
-            initialOptions
+            {} as Partial<PlotOptions>,
+            { sortOrdinalDomains: DEFAULTS.sortOrdinalDomains } as Partial<PlotOptions>,
+            smartDefaultPlotOptions(opts) as any,
+            initialOptions as any
         ) as ResolvedPlotOptions;
     }
 
@@ -510,14 +510,14 @@
                 padding: 0,
                 align: 0
             },
-            color: { type: 'auto', unknown: DEFAULTS.unknown },
+            color: { type: 'auto' as any, unknown: DEFAULTS.unknown },
             length: { type: 'linear' },
             symbol: { type: 'ordinal' },
             fx: { type: 'band', axis: 'top' },
             fy: { type: 'band', axis: 'right' },
             locale: DEFAULTS.locale,
             css: DEFAULTS.css
-        };
+        } as ResolvedPlotOptions;
     }
 
     const mapXY = $derived((x: RawValue, y: RawValue) => {
@@ -548,7 +548,7 @@
                 {#if children}
                     {@render children({
                         width,
-                        height,
+                        height: height ?? 0,
                         options: plotOptions,
                         scales: plotState.scales,
                         mapXY,
@@ -564,7 +564,7 @@
         {#if overlay}<div class="plot-overlay">
                 {@render overlay?.({
                     width,
-                    height,
+                    height: height ?? 0,
                     options: plotOptions,
                     scales: plotState.scales,
                     mapXY,

--- a/src/lib/types/plot.ts
+++ b/src/lib/types/plot.ts
@@ -556,7 +556,20 @@ export type PlotOptions = {
      * options, and resolved scales as arguments.
      */
     children: Snippet<
-        [{ width: number; height: number; options: ResolvedPlotOptions; scales: PlotScales }]
+        [
+            {
+                width: number;
+                height: number;
+                options: ResolvedPlotOptions;
+                scales: PlotScales;
+                hasProjection: boolean;
+                hasExplicitAxisX: boolean;
+                hasExplicitAxisY: boolean;
+                hasExplicitGridX: boolean;
+                hasExplicitGridY: boolean;
+                [key: string]: any;
+            }
+        ]
     >;
     /**
      * You can use the header snippet to render a custom title and subtitle for
@@ -578,7 +591,20 @@ export type PlotOptions = {
      * in front of the SVG body of your plot, e.g. for HTML tooltips.
      */
     overlay: Snippet<
-        [{ width: number; height: number; options: ResolvedPlotOptions; scales: PlotScales }]
+        [
+            {
+                width: number;
+                height: number;
+                options: ResolvedPlotOptions;
+                scales: PlotScales;
+                hasProjection: boolean;
+                hasExplicitAxisX: boolean;
+                hasExplicitAxisY: boolean;
+                hasExplicitGridX: boolean;
+                hasExplicitGridY: boolean;
+                [key: string]: any;
+            }
+        ]
     >;
     /**
      * snippet for rendering custom facet axes


### PR DESCRIPTION
Fixes svelte-check errors in the core plot infrastructure files.

## Changes

- **`src/lib/Mark.svelte`** — `as any` casts for dynamic channel/property indexing, structural type fix for `Mark` generic, null-safe record initialization, corrected `resolveChannel` and `projectXY` call signatures
- **`src/lib/core/Plot.svelte`** — `(error as Error).message` in catch blocks, null-coalescing for nullable numeric fields, casts for dynamic scale key indexing and `mergeDeep` args
- **`src/lib/core/FacetAxes.svelte`** — `fxValues as string[]` for `scaleBand` domain, casts for `tickFormat` and `scaleFn`, handle `axis === 'both'` anchor case
- **`src/lib/core/FacetGrid.svelte`** — `fxValues as string[]`, `fyValues as string[]`, `facetX as string`, `facetY as string`
- **`src/lib/Plot.svelte`** — `projection as any` for `.type` access, casts for string scale key indexing, `null` → `undefined` for snippet props, `(error as Error).message`
- **`src/lib/types/plot.ts`** — type improvements to support the above fixes

resolves #407
resolves #408
resolves #410
resolves #411
resolves #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)