### PR TITLE
fix: refactor unused expressions into proper statements

### DIFF
--- a/src/lib/helpers/arrowPath.ts
+++ b/src/lib/helpers/arrowPath.ts
@@ -80,15 +80,22 @@ export function arrowPath(
                     sign * Math.sign(insetEnd)
                 );
                 lineAngle += Math.atan2(y - cy, x - cx) - Math.atan2(y2 - cy, x2 - cx);
-                ((x2 = x), (y2 = y));
+                x2 = x;
+                y2 = y;
             }
         } else {
             // For inset straight arrows, offset along the straight line.
             const dx = x2 - x1,
                 dy = y2 - y1,
                 d = Math.hypot(dx, dy);
-            if (insetStart) ((x1 += (dx / d) * insetStart), (y1 += (dy / d) * insetStart));
-            if (insetEnd) ((x2 -= (dx / d) * insetEnd), (y2 -= (dy / d) * insetEnd));
+            if (insetStart) {
+                x1 += (dx / d) * insetStart;
+                y1 += (dy / d) * insetStart;
+            }
+            if (insetEnd) {
+                x2 -= (dx / d) * insetEnd;
+                y2 -= (dy / d) * insetEnd;
+            }
         }
     }
 

--- a/src/lib/transforms/bollinger.ts
+++ b/src/lib/transforms/bollinger.ts
@@ -74,18 +74,21 @@ function bollinger(values: number[], N: number, K: number[]) {
     // compute sum and square of sums
     for (let n = Math.min(N - 1, values.length); i < n; ++i) {
         const value = values[i];
-        ((sum += value), (sumSquared += value ** 2));
+        sum += value;
+        sumSquared += value ** 2;
     }
     for (let n = values.length; i < n; ++i) {
         const value = values[i];
-        ((sum += value), (sumSquared += value ** 2));
+        sum += value;
+        sumSquared += value ** 2;
         const mean = sum / N;
         const deviation = Math.sqrt((sumSquared - sum ** 2 / N) / (N - 1));
         for (let j = 0; j < K.length; ++j) {
             bands[j][i] = mean + deviation * K[j];
         }
         const value0 = values[i - N + 1];
-        ((sum -= value0), (sumSquared -= value0 ** 2));
+        sum -= value0;
+        sumSquared -= value0 ** 2;
     }
     return bands;
 }

--- a/src/lib/transforms/density.ts
+++ b/src/lib/transforms/density.ts
@@ -136,7 +136,7 @@ function bandwidthSilverman(x: number[]) {
     const hi = Math.sqrt(xvar!);
     let lo: number;
     if (!(lo = Math.min(hi, iqr / 1.34))) {
-        (lo = hi) || (lo = Math.abs(x[1])) || (lo = 1);
+        lo = hi || Math.abs(x[1]) || 1;
     }
     return lo * Math.pow(x.length, -0.2);
 }

--- a/src/theme/components/GlobalLayout.svelte
+++ b/src/theme/components/GlobalLayout.svelte
@@ -49,7 +49,7 @@
         if (themeOptions.pwa) pwaComponent = (await import('./pwa/Pwa.svelte')).default;
     });
 
-    rest;
+    void rest;
 </script>
 
 <svelte:window onscroll={() => ($oldScrollY = $scrollY)} bind:scrollY={$scrollY} />

--- a/src/theme/components/IconifyIcon.svelte
+++ b/src/theme/components/IconifyIcon.svelte
@@ -1,7 +1,7 @@
 <script>
     const { collection, name, ...rest } = $props();
 
-    rest;
+    void rest;
 </script>
 
 <div class="i-{collection}-{name}"></div>

--- a/src/theme/components/NavItem.svelte
+++ b/src/theme/components/NavItem.svelte
@@ -29,7 +29,7 @@
     } = $props();
 
     let active = $derived(page.url.pathname.startsWith(`${to.endsWith('/') ? to : `${to}/`}`));
-    rest;
+    void rest;
 </script>
 
 {#if items && items.length}


### PR DESCRIPTION
## Summary
- Refactors comma expressions (e.g. `((sum += value), (sumSquared += value ** 2))`) into separate statements
- Changes bare `rest;` to `void rest;` in Svelte theme components for explicit reactivity tracking
- Fixes all 10 `no-unused-expressions` oxlint warnings across 6 files

## Files changed
- `src/lib/helpers/arrowPath.ts` — 3 comma expressions → separate statements
- `src/lib/transforms/bollinger.ts` — 3 comma expressions → separate statements
- `src/lib/transforms/density.ts` — 1 `(lo = hi) || ...` → `lo = hi || ...`
- `src/theme/components/GlobalLayout.svelte` — `rest;` → `void rest;`
- `src/theme/components/NavItem.svelte` — `rest;` → `void rest;`
- `src/theme/components/IconifyIcon.svelte` — `rest;` → `void rest;`

## Test plan
- [x] `pnpm exec oxlint --type-aware` — 0 `no-unused-expressions` warnings
- [ ] `pnpm test` — all tests pass
- [ ] `pnpm check` — 0 svelte-check errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)