### PR TITLE
chore: replace \$lib imports with svelteplot package name in docs 

### DIFF
--- a/src/routes/examples/dot/beeswarm-bubbles.svelte
+++ b/src/routes/examples/dot/beeswarm-bubbles.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <script lang="ts">
-    import { Plot, Dot } from '$lib';
+    import { Plot, Dot } from 'svelteplot';
 
     const { countries } = $props();
 </script>

--- a/src/routes/examples/frame/ggplot-style.svelte
+++ b/src/routes/examples/frame/ggplot-style.svelte
@@ -12,7 +12,7 @@
         Line,
         GridX,
         GridY
-    } from '$lib/index.js';
+    } from 'svelteplot';
 
     const { aapl } = $props();
 </script>

--- a/src/routes/examples/trail/tdf-canvas.svelte
+++ b/src/routes/examples/trail/tdf-canvas.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <script lang="ts">
-    import { Plot, Line, Trail } from '$lib/index.js';
+    import { Plot, Line, Trail } from 'svelteplot';
 
     let { tdf } = $props();
 </script>

--- a/src/routes/examples/trail/tdf.svelte
+++ b/src/routes/examples/trail/tdf.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <script lang="ts">
-    import { Plot, Line, Trail } from '$lib/index.js';
+    import { Plot, Line, Trail } from 'svelteplot';
 
     let { tdf } = $props();
 </script>

--- a/src/routes/features/facets/+page.md
+++ b/src/routes/features/facets/+page.md
@@ -6,7 +6,7 @@ Facets are a way to split a plot into multiple panels.
 
 ```svelte live
 <script>
-    import { Plot, Dot, AxisX } from '$lib/index';
+    import { Plot, Dot, AxisX } from 'svelteplot';
     import { page } from '$app/state';
     const { penguins } = $derived(page.data.data);
 </script>
@@ -91,7 +91,7 @@ Apply top-level facet options automatically:
 
 ```svelte --live
 <script>
-    import { Plot, Dot, Frame } from '$lib/index';
+    import { Plot, Dot, Frame } from 'svelteplot';
     import { page } from '$app/state';
     let { penguins } = $derived(page.data.data);
 </script>
@@ -124,7 +124,7 @@ Bar chart facets
 
 ```svelte live
 <script>
-    import { Plot, BarY } from '$lib/index';
+    import { Plot, BarY } from 'svelteplot';
     const resultsLong = [
         { party: 'Union', year: 2025, percent: 30 },
         { party: 'Union', year: 2021, percent: 22 },

--- a/src/routes/features/markers/+page.md
+++ b/src/routes/features/markers/+page.md
@@ -98,7 +98,7 @@ Note that for the interpolation methods `basis`, `bundle`, and `step`, the marke
     import { Plot, LineY, Dot } from 'svelteplot';
     import Slider from '$shared/ui/Slider.svelte';
     import Select from '$shared/ui/Select.svelte';
-    import type { CurveName } from '$lib/types/index.js';
+    import type { CurveName } from 'svelteplot/types/index.js';
 
     // curve demo
     const numbers = [
@@ -144,7 +144,7 @@ You can also specify a custom marker icon using the `marker` snippet:
 ```svelte live
 <script lang="ts">
     import { Plot, Line } from 'svelteplot';
-    import type { Datasets } from '$lib/types/index.js';
+    import type { Datasets } from 'svelteplot/types/index.js';
 
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);

--- a/src/routes/features/plot/+page.md
+++ b/src/routes/features/plot/+page.md
@@ -394,7 +394,7 @@ SveltePlot provides a lot of convenience features with the unfortunate side-effe
 
 ```svelte live
 <script>
-    import Plot from '$lib/core/Plot.svelte';
+    import Plot from 'svelteplot/core/Plot.svelte';
     import { Line } from 'svelteplot';
     import { page } from '$app/state';
     const { aapl } = $derived(page.data.data);

--- a/src/routes/getting-started/+page.md
+++ b/src/routes/getting-started/+page.md
@@ -13,7 +13,7 @@ You can use SveltePlot inside any platform that supports Svelte 5, such as [Stac
 
 ```svelte live
 <script>
-    import { Plot, RectY, binX } from '$lib/index';
+    import { Plot, RectY, binX } from 'svelteplot';
     import { randomNormal } from 'd3-random';
 
     const randomNumbers = new Array(10000)
@@ -72,7 +72,7 @@ pnpm add svelteplot
 
 ```svelte live
 <script>
-    import { Plot, BarX } from '$lib/index';
+    import { Plot, BarX } from 'svelteplot';
 </script>
 
 <Plot grid testid="four-bars" y={['A', 'B', 'C', 'D']}>

--- a/src/routes/introduction/+page.md
+++ b/src/routes/introduction/+page.md
@@ -345,7 +345,7 @@ This scatterplot suffers from overplotting: many dots are drawn in the same spot
 ```svelte --live
 <script>
     import { Plot, Rect, bin } from 'svelteplot';
-    import Mark from '$lib/Mark.svelte';
+    import Mark from 'svelteplot/Mark.svelte';
     import { page } from '$app/state';
     let { olympians } = $derived(page.data.data);
 
@@ -384,7 +384,7 @@ We can use the [binX transform](/transforms/bin) to compute a weight distributio
         DotX,
         binX
     } from 'svelteplot';
-    import Mark from '$lib/Mark.svelte';
+    import Mark from 'svelteplot/Mark.svelte';
     import { page } from '$app/state';
     let { olympians } = $derived(page.data.data);
 </script>
@@ -431,7 +431,7 @@ Or we can use the built-in [faceting](/features/facets) to look at the distribut
         DotX,
         binX
     } from 'svelteplot';
-    import Mark from '$lib/Mark.svelte';
+    import Mark from 'svelteplot/Mark.svelte';
     import { page } from '$app/state';
     let { olympians } = $derived(page.data.data);
 </script>

--- a/src/routes/marks/area/+page.md
+++ b/src/routes/marks/area/+page.md
@@ -14,7 +14,7 @@ The **area mark** draws the region between a baseline (x1, y1) and a topline (x2
 
 ```svelte live
 <script lang="ts">
-    import { Plot, AreaY } from '$lib/index';
+    import { Plot, AreaY } from 'svelteplot';
     import { page } from '$app/state';
     const { aapl } = $derived(page.data.data);
     import { getContext } from 'svelte';
@@ -43,7 +43,7 @@ If you supply `undefined` values, the area mark will create gaps in the visualiz
 
 ```svelte live
 <script lang="ts">
-    import { Plot, AreaY } from '$lib/index';
+    import { Plot, AreaY } from 'svelteplot';
     import { page } from '$app/state';
     const { aapl } = $derived(page.data.data);
     import { getContext } from 'svelte';
@@ -82,7 +82,7 @@ In order to interpolate across undefined values you need to filter them, e.g. us
 
 ```svelte live
 <script lang="ts">
-    import { Plot, AreaY } from '$lib/index';
+    import { Plot, AreaY } from 'svelteplot';
     import { page } from '$app/state';
     const { aapl } = $derived(page.data.data);
     import { getContext } from 'svelte';
@@ -141,7 +141,7 @@ If you need a different baseline you can pass <b>y1</b> and <b>y2</b> channels i
 
 ```svelte live
 <script>
-    import { Plot, AreaY } from '$lib/index';
+    import { Plot, AreaY } from 'svelteplot';
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);
     import { getContext } from 'svelte';
@@ -287,7 +287,7 @@ You can use the **offset** option to create a streamgraph:
 
 ```svelte live
 <script>
-    import { Plot, AreaY } from '$lib/index.js';
+    import { Plot, AreaY } from 'svelteplot';
     import { Select } from '$shared/ui';
     import { page } from '$app/stores';
     import { getContext } from 'svelte';
@@ -387,7 +387,7 @@ Required channels for horizontal area charts:
         AreaY,
         Line,
         RuleY
-    } from '$lib/index.js';
+    } from 'svelteplot';
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);
     import { getContext } from 'svelte';
@@ -445,7 +445,7 @@ The example below demonstrates how to use the Area mark to create a custom area 
 
 ```svelte live
 <script lang="ts">
-    import { Plot, Area, Line } from '$lib/index.js';
+    import { Plot, Area, Line } from 'svelteplot';
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);
     import { getContext } from 'svelte';

--- a/src/routes/marks/arrow/+page.md
+++ b/src/routes/marks/arrow/+page.md
@@ -17,7 +17,7 @@ Metro dataset:
 
 ```svelte live
 <script lang="ts">
-    import { Plot, Arrow, Dot, Text } from '$lib/index.js';
+    import { Plot, Arrow, Dot, Text } from 'svelteplot';
     import { page } from '$app/state';
     let { metros } = $derived(page.data.data);
 
@@ -120,7 +120,7 @@ Works as well with a point scale:
         Text,
         AxisY,
         GridY
-    } from '$lib/index.js';
+    } from 'svelteplot';
     import { page } from '$app/state';
     let { metros } = $derived(page.data.data);
 </script>
@@ -166,7 +166,7 @@ Another thing you can use the arrow mark for is drawing network diagrams:
         Dot,
         Pointer,
         Text
-    } from '$lib/index.js';
+    } from 'svelteplot';
     import { json } from 'd3-fetch';
     import {
         forceSimulation,
@@ -310,7 +310,7 @@ Event handlers can be attached to arrows for interactive visualizations:
 
 ```svelte live
 <script lang="ts">
-    import { Plot, Arrow, Dot } from '$lib/index.js';
+    import { Plot, Arrow, Dot } from 'svelteplot';
 
     import Slider from '$shared/ui/Slider.svelte';
     import Select from '$shared/ui/Select.svelte';

--- a/src/routes/marks/bar/BarPlot.svelte
+++ b/src/routes/marks/bar/BarPlot.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Plot, BarY, RuleY } from '$lib/index.js';
+    import { Plot, BarY, RuleY } from 'svelteplot';
 
     import { page } from '$app/stores';
     let { alphabet } = $derived($page.data.data);

--- a/src/routes/marks/bar/StackedBarPlot.svelte
+++ b/src/routes/marks/bar/StackedBarPlot.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Plot, BarX } from '$lib/index.js';
+    import { Plot, BarX } from 'svelteplot';
     import { rollups } from 'd3-array';
 
     import { page } from '$app/stores';

--- a/src/routes/marks/bollinger/+page.md
+++ b/src/routes/marks/bollinger/+page.md
@@ -64,7 +64,7 @@ For more flexibility you can also use the bollingerX and bollingerY as transform
         Line,
         Area,
         bollingerY
-    } from '$lib/index';
+    } from 'svelteplot';
     import { Slider } from '$shared/ui';
 
     import { page } from '$app/state';

--- a/src/routes/marks/frame/+page.md
+++ b/src/routes/marks/frame/+page.md
@@ -71,7 +71,7 @@ You can use the explicit frame and grid marks to create ggplot style charts:
         Line,
         GridX,
         GridY
-    } from '$lib/index.js';
+    } from 'svelteplot';
     import { page } from '$app/state';
     const { aapl } = $derived(page.data.data);
 </script>

--- a/src/routes/marks/grid/+page.md
+++ b/src/routes/marks/grid/+page.md
@@ -6,7 +6,7 @@ The Grid mark renders the faint grid lines in the background of your plots (the 
 
 ```svelte live
 <script lang="ts">
-    import { Plot, Line } from '$lib/index.js';
+    import { Plot, Line } from 'svelteplot';
 
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);
@@ -37,7 +37,7 @@ with the axes marks.
 
 ```svelte live
 <script lang="ts">
-    import { Plot, GridX, GridY } from '$lib/index.js';
+    import { Plot, GridX, GridY } from 'svelteplot';
 </script>
 
 <Plot

--- a/src/routes/marks/line/+page.md
+++ b/src/routes/marks/line/+page.md
@@ -39,7 +39,7 @@ If the **x** and **y** options are not defined, the line mark assumes that the d
 ```svelte live
 <script lang="ts">
     import { Plot, Line, RuleY } from 'svelteplot';
-    import type { Datasets } from '$lib/types/index.js';
+    import type { Datasets } from 'svelteplot/types/index.js';
 
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);
@@ -243,7 +243,7 @@ BLS Demo:
 ```svelte live
 <script lang="ts">
     import { Plot, Line, RuleY } from 'svelteplot';
-    import type { Datasets } from '$lib/types/index.js';
+    import type { Datasets } from 'svelteplot/types/index.js';
 
     import { page } from '$app/state';
     let { bls } = $derived(page.data.data);
@@ -339,7 +339,7 @@ The [LineY constructor](/marks/line#LineY) provides default channel definitions 
 ```svelte live
 <script lang="ts">
     import { Plot, LineY } from 'svelteplot';
-    import type { Datasets } from '$lib/types/index.js';
+    import type { Datasets } from 'svelteplot/types/index.js';
     import { randomNormal } from 'd3-random';
     import { range, cumsum } from 'd3-array';
 </script>
@@ -534,7 +534,7 @@ You can set the line interpolation using the **interpolation** option.
 
 ```svelte live
 <script>
-    import { Plot, LineY, Dot } from '$lib/index.js';
+    import { Plot, LineY, Dot } from 'svelteplot';
     import Slider from '$shared/ui/Slider.svelte';
     import Select from '$shared/ui/Select.svelte';
 

--- a/src/routes/marks/line/CO2Decades.svelte
+++ b/src/routes/marks/line/CO2Decades.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Plot, Line, Pointer, Text, RectY, RuleY, Dot, selectLast } from '$lib/index.js';
+    import { Plot, Line, Pointer, Text, RectY, RuleY, Dot, selectLast } from 'svelteplot';
     import { range } from 'd3-array';
     import { page } from '$app/stores';
 

--- a/src/routes/marks/line/CurveDemo.svelte
+++ b/src/routes/marks/line/CurveDemo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Plot, LineY, Dot } from '$lib/index.js';
+    import { Plot, LineY, Dot } from 'svelteplot';
     import Slider from '$shared/ui/Slider.svelte';
     import Select from '$shared/ui/Select.svelte';
     import type { CurveName } from 'svelteplot/types/index.js';

--- a/src/routes/marks/link/+page.md
+++ b/src/routes/marks/link/+page.md
@@ -8,7 +8,7 @@ For connecting two points with a line.
 
 ```svelte live
 <script lang="ts">
-    import { Plot, Link, Dot, Text } from '$lib/index.js';
+    import { Plot, Link, Dot, Text } from 'svelteplot';
     import { page } from '$app/state';
     let { metros } = $derived(page.data.data);
 
@@ -71,7 +71,7 @@ Link support spherical projections:
         Link,
         Dot,
         Text
-    } from '$lib/index.js';
+    } from 'svelteplot';
     import { page } from '$app/state';
     import * as topojson from 'topojson-client';
 

--- a/src/routes/marks/rule/+page.md
+++ b/src/routes/marks/rule/+page.md
@@ -141,12 +141,7 @@ You can combine the rule marks with the group transform to show the mean, median
 
 ```svelte live
 <script lang="ts">
-    import {
-        Plot,
-        RuleY,
-        groupZ,
-        Dot
-    } from 'svelteplot';
+    import { Plot, RuleY, groupZ, Dot } from 'svelteplot';
 
     import { page } from '$app/state';
     let { penguins } = $derived(page.data.data);

--- a/src/routes/marks/rule/+page.md
+++ b/src/routes/marks/rule/+page.md
@@ -39,7 +39,7 @@ Like most other marks, rules also accept data for displaying multiple lines at o
 ```svelte live
 <script lang="ts">
     import { Plot, Line, RuleY } from 'svelteplot';
-    import type { Datasets } from '$lib/types/index.js';
+    import type { Datasets } from 'svelteplot/types/index.js';
 
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);
@@ -62,7 +62,7 @@ Rules can be used for barcode plots:
 
 ```svelte live
 <script lang="ts">
-    import { Plot, RuleX } from '$lib/index.js';
+    import { Plot, RuleX } from 'svelteplot';
     import { range } from 'd3-array';
     import { randomNormal, randomLcg } from 'd3-random';
 
@@ -110,7 +110,7 @@ Or candlestick ([demo](https://svelte.dev/playground/f2b2ada0c65d403c92777250c14
 
 ```svelte live
 <script lang="ts">
-    import { Plot, RuleX } from '$lib/index.js';
+    import { Plot, RuleX } from 'svelteplot';
 
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);
@@ -146,7 +146,7 @@ You can combine the rule marks with the group transform to show the mean, median
         RuleY,
         groupZ,
         Dot
-    } from '$lib/index.js';
+    } from 'svelteplot';
 
     import { page } from '$app/state';
     let { penguins } = $derived(page.data.data);

--- a/src/routes/marks/rule/BarcodeExample.svelte
+++ b/src/routes/marks/rule/BarcodeExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Plot, RuleX } from '$lib/index.js';
+    import { Plot, RuleX } from 'svelteplot';
     import { range } from 'd3-array';
     import { randomNormal, randomLcg } from 'd3-random';
     import Code from '../../Code.svelte';
@@ -13,7 +13,7 @@
 
 <Code
     code={`<scr${'ipt>'}
-    import { Plot, RuleX } from '$lib/index.js';
+    import { Plot, RuleX } from 'svelteplot';
     import { randomNormal } from 'd3-random';
     import { range } from 'd3-array';
 </scr${'ipt>'}

--- a/src/routes/marks/rule/CandlestickExample.svelte
+++ b/src/routes/marks/rule/CandlestickExample.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Plot, RuleX } from '$lib/index.js';
+    import { Plot, RuleX } from 'svelteplot';
     import { getContext } from 'svelte';
     import Code from '../../Code.svelte';
 

--- a/src/routes/marks/rule/SineRules.svelte
+++ b/src/routes/marks/rule/SineRules.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-    import { Plot, RuleX, RuleY } from '$lib/index.js';
-    import AxisX from '$lib/marks/AxisX.svelte';
-    import GridX from '$lib/marks/GridX.svelte';
-    import GridY from '$lib/marks/GridY.svelte';
+    import { Plot, RuleX, RuleY } from 'svelteplot';
+    import AxisX from 'svelteplot/marks/AxisX.svelte';
+    import GridX from 'svelteplot/marks/GridX.svelte';
+    import GridY from 'svelteplot/marks/GridY.svelte';
     import { range } from 'd3-array';
 
     const ticks = range(0, 3.01, 0.5).map((d) => d * Math.PI);

--- a/src/routes/marks/rule/__+page.svelte
+++ b/src/routes/marks/rule/__+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Plot, Line, RuleX, RuleY } from '$lib/index.js';
+    import { Plot, Line, RuleX, RuleY } from 'svelteplot';
     import { getContext } from 'svelte';
     import SineRules from './SineRules.svelte';
     import BarcodeExample from './BarcodeExample.svelte';

--- a/src/routes/marks/tick/+page.md
+++ b/src/routes/marks/tick/+page.md
@@ -12,7 +12,7 @@ The tickX mark shows a vertical bar for each x position. Based on an example fro
 
 ```svelte live
 <script lang="ts">
-    import { Plot, RuleX, TickX } from '$lib/index.js';
+    import { Plot, RuleX, TickX } from 'svelteplot';
     import { page } from '$app/state';
     let { stateage } = $derived(page.data.data);
 </script>
@@ -38,7 +38,7 @@ Shows a horizontal bar for each x position.
 
 ```svelte live
 <script lang="ts">
-    import { Plot, RuleY, TickY } from '$lib/index.js';
+    import { Plot, RuleY, TickY } from 'svelteplot';
     import { Slider } from '$shared/ui';
     import { page } from '$app/state';
     let { stateage } = $derived(page.data.data);
@@ -79,7 +79,7 @@ Same idea but with facet:
 
 ```svelte live
 <script lang="ts">
-    import { Plot, RuleY, TickY } from '$lib/index.js';
+    import { Plot, RuleY, TickY } from 'svelteplot';
 
     import { page } from '$app/state';
     const { stateage } = $derived(page.data.data);

--- a/src/routes/marks/trail/+page.md
+++ b/src/routes/marks/trail/+page.md
@@ -14,7 +14,7 @@ In the example below we use the line width to represent elevation along the 12th
 
 ```svelte live
 <script lang="ts">
-    import { Plot, Line, Trail } from '$lib/index.js';
+    import { Plot, Line, Trail } from 'svelteplot';
     import { page } from '$app/state';
 
     let { tdf } = $derived(page.data.data);
@@ -56,7 +56,7 @@ By default, the trail width (bound to the `r` channel) is scaled using a square-
 
 ```svelte live
 <script lang="ts">
-    import { Plot, Trail } from '$lib/index.js';
+    import { Plot, Trail } from 'svelteplot';
     import { RadioInput } from '$shared/ui';
     import { page } from '$app/state';
 

--- a/src/routes/transforms/bin/+page.md
+++ b/src/routes/transforms/bin/+page.md
@@ -91,7 +91,7 @@ Alternatively, you can also map to the _r_ channel.
 ```svelte live
 <script>
     import { Plot, DotX, binX } from 'svelteplot';
-    import Mark from '$lib/Mark.svelte';
+    import Mark from 'svelteplot/Mark.svelte';
     import { page } from '$app/state';
     let { olympians } = $derived(page.data.data);
 
@@ -117,7 +117,7 @@ Alternatively, you can also map to the _r_ channel.
 ```svelte live
 <script>
     import { Plot, DotX, binX } from 'svelteplot';
-    import Mark from '$lib/Mark.svelte';
+    import Mark from 'svelteplot/Mark.svelte';
     import { page } from '$app/state';
     let { olympians } = $derived(page.data.data);
 </script>
@@ -546,7 +546,7 @@ You can also map to _r_ as output channel:
 ```svelte live
 <script>
     import { Plot, Dot, bin } from 'svelteplot';
-    import Mark from '$lib/Mark.svelte';
+    import Mark from 'svelteplot/Mark.svelte';
     import { page } from '$app/state';
     let { olympians } = $derived(page.data.data);
 
@@ -590,7 +590,7 @@ Requires _input_ channels _x_ and _y_. Valid output channels for `bin()` are _fi
 ```svelte live
 <script>
     import { Plot, Rect, bin } from 'svelteplot';
-    import Mark from '$lib/Mark.svelte';
+    import Mark from 'svelteplot/Mark.svelte';
     import { page } from '$app/state';
     let { olympians } = $derived(page.data.data);
     import { getContext } from 'svelte';

--- a/src/routes/transforms/dodge/+page.md
+++ b/src/routes/transforms/dodge/+page.md
@@ -16,7 +16,7 @@ Unlike other transforms, the dodge transform is applied _after_ the positions ha
 
 ```svelte live
 <script>
-    import { Plot, DotX, RuleY } from '$lib';
+    import { Plot, DotX, RuleY } from 'svelteplot';
     import { page } from '$app/state';
 
     const { cars } = $derived(page.data.data);
@@ -51,7 +51,7 @@ Compare this to a conventional histogram using a rect mark.
 
 ```svelte live
 <script>
-    import { Plot, RectY, RuleY, binX } from '$lib';
+    import { Plot, RectY, RuleY, binX } from 'svelteplot';
     import { page } from '$app/state';
 
     const { cars } = $derived(page.data.data);
@@ -82,7 +82,7 @@ If you use the r channel to specify the radius of each dot, the dodge transform 
 
 ```svelte live
 <script>
-    import { Plot, Dot } from '$lib';
+    import { Plot, Dot } from 'svelteplot';
     import { page } from '$app/state';
 
     const { countries_2020: countries } = $derived(
@@ -112,7 +112,7 @@ This also works with other positional marks, such as texts:
 
 ```svelte live
 <script>
-    import { Plot, Dot, Text } from '$lib';
+    import { Plot, Dot, Text } from 'svelteplot';
     import { page } from '$app/state';
 
     const { countries_2020: countries } = $derived(

--- a/src/routes/transforms/filter/+page.md
+++ b/src/routes/transforms/filter/+page.md
@@ -8,7 +8,7 @@ Since the filter transform only affects the mark’s index and not the channel v
 
 ```svelte live
 <script lang="ts">
-    import { Plot, BarY, filter } from '$lib/index';
+    import { Plot, BarY, filter } from 'svelteplot';
     import { page } from '$app/state';
     const { alphabet } = $derived(page.data.data);
     import { getContext } from 'svelte';

--- a/src/routes/transforms/interval/+page.md
+++ b/src/routes/transforms/interval/+page.md
@@ -35,7 +35,7 @@ In contrast, a [rectY](/marks/rect) mark with the interval option and the day in
 ```svelte live
 <script lang="ts">
     import { Plot, RectY, RuleY } from 'svelteplot';
-    import type { Datasets } from '$lib/types/index.js';
+    import type { Datasets } from 'svelteplot/types/index.js';
 
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);
@@ -76,7 +76,7 @@ The meaning of the interval mark option depends on the associated mark, such as 
 ```svelte live
 <script lang="ts">
     import { Plot, BarY, RuleY } from 'svelteplot';
-    import type { Datasets } from '$lib/types/index.js';
+    import type { Datasets } from 'svelteplot/types/index.js';
 
     import { page } from '$app/state';
     let { aapl } = $derived(page.data.data);

--- a/src/routes/why-svelteplot/+page.md
+++ b/src/routes/why-svelteplot/+page.md
@@ -255,8 +255,8 @@ Here's an example where we're binding a live-updated dataset to a [Line mark](/m
         AreaY,
         Dot,
         Text
-    } from '$lib/index.js';
-    import { noise } from '$lib/helpers/noise.js';
+    } from 'svelteplot';
+    import { noise } from 'svelteplot/helpers/noise.js';
 
     let rand: number[] = $state([]);
     let maxLen = $state(200);


### PR DESCRIPTION
This pull request updates all example and documentation files to import SveltePlot components and types directly from the published `svelteplot` package, rather than from local `$lib` paths. This change standardizes imports, simplifies code samples, and aligns documentation with how users should consume the library.

**Standardization of imports in examples and documentation:**

- All SveltePlot components (`Plot`, marks, transforms, etc.) are now imported from `'svelteplot'` or `'svelteplot/...'` instead of `'$lib'` or `'$lib/index.js'`. This affects numerous example `.svelte` files and markdown documentation. [[1]](diffhunk://#diff-709f7dfd37f8a680599d1e76c7e76f91e9fb2babc9159f0f75db4ad5997b1bcdL12-R12) [[2]](diffhunk://#diff-a40afa743989ba7c2437d46b0b56d5b88ffc3e499685e36609d01a8cbd71d5ebL15-R15) [[3]](diffhunk://#diff-66528ffa43bc987a2f94563c62654ecae7860d1ff3da1dfcfee12efb1503995bL10-R10) [[4]](diffhunk://#diff-60f0f7fd3bc0ca51ffd9b320db111131a81cc9cb6c2b8d960b7c8cedb5fd7701L10-R10) [[5]](diffhunk://#diff-a6f6c094dc462789d9fc27f4416cd04fb3dc2e24b6387a72fc82e772c4872389L9-R9) [[6]](diffhunk://#diff-a6f6c094dc462789d9fc27f4416cd04fb3dc2e24b6387a72fc82e772c4872389L94-R94) [[7]](diffhunk://#diff-a6f6c094dc462789d9fc27f4416cd04fb3dc2e24b6387a72fc82e772c4872389L127-R127) [[8]](diffhunk://#diff-656632aa42409ff9841960d948bc9097fff959e0face638e4c9163226e733ba6L397-R397) [[9]](diffhunk://#diff-a144a8fc3b585f1ae2aaa62c294d30f49c8332811746622afb1252433c8adcf8L16-R16) [[10]](diffhunk://#diff-a144a8fc3b585f1ae2aaa62c294d30f49c8332811746622afb1252433c8adcf8L75-R75) [[11]](diffhunk://#diff-a40dc4163053a5b751a53e5a8870476055ef6219785ffd03141961cabc80f55bL348-R348) [[12]](diffhunk://#diff-a40dc4163053a5b751a53e5a8870476055ef6219785ffd03141961cabc80f55bL387-R387) [[13]](diffhunk://#diff-a40dc4163053a5b751a53e5a8870476055ef6219785ffd03141961cabc80f55bL434-R434) [[14]](diffhunk://#diff-9a6971f03e66c99665f3a26cc9a7a8dcb10632d0361300dd7c440cb517b62b15L17-R17) [[15]](diffhunk://#diff-9a6971f03e66c99665f3a26cc9a7a8dcb10632d0361300dd7c440cb517b62b15L46-R46) [[16]](diffhunk://#diff-9a6971f03e66c99665f3a26cc9a7a8dcb10632d0361300dd7c440cb517b62b15L85-R85) [[17]](diffhunk://#diff-9a6971f03e66c99665f3a26cc9a7a8dcb10632d0361300dd7c440cb517b62b15L144-R144) [[18]](diffhunk://#diff-9a6971f03e66c99665f3a26cc9a7a8dcb10632d0361300dd7c440cb517b62b15L290-R290) [[19]](diffhunk://#diff-9a6971f03e66c99665f3a26cc9a7a8dcb10632d0361300dd7c440cb517b62b15L390-R390) [[20]](diffhunk://#diff-9a6971f03e66c99665f3a26cc9a7a8dcb10632d0361300dd7c440cb517b62b15L448-R448) [[21]](diffhunk://#diff-bd0a6c9a54a2c58dc8e7d379bacf4a08ab4dae993dc8f5cfdbc27cfb688ac32cL20-R20) [[22]](diffhunk://#diff-bd0a6c9a54a2c58dc8e7d379bacf4a08ab4dae993dc8f5cfdbc27cfb688ac32cL123-R123) [[23]](diffhunk://#diff-bd0a6c9a54a2c58dc8e7d379bacf4a08ab4dae993dc8f5cfdbc27cfb688ac32cL169-R169) [[24]](diffhunk://#diff-bd0a6c9a54a2c58dc8e7d379bacf4a08ab4dae993dc8f5cfdbc27cfb688ac32cL313-R313) [[25]](diffhunk://#diff-62772e2a8579c8f43274ee1500c7e26cafeda49e8eb5ec2869624cc43b07a630L2-R2) [[26]](diffhunk://#diff-88b0fb143e82475cc8d538ab856556b5735cc32c6d11bda0d10c873e9e1416daL2-R2) [[27]](diffhunk://#diff-ba9a4c5162f01464cf36f84bc95ff4bb2eac81966c3a0ada13f2e9f6db7d73f3L67-R67) [[28]](diffhunk://#diff-ea9b87350e49859ee28ccfbf8aab9449488e5649538c978950596445cdb41507L74-R74) [[29]](diffhunk://#diff-eb12d69cec40e905e492e5a2ae57f9180625060075784fe6abddf766f76ca135L9-R9) [[30]](diffhunk://#diff-eb12d69cec40e905e492e5a2ae57f9180625060075784fe6abddf766f76ca135L40-R40)
- Imports of SveltePlot types (e.g., `CurveName`, `Datasets`) are now sourced from `'svelteplot/types/index.js'` instead of `'$lib/types/index.js'`. [[1]](diffhunk://#diff-8e7a1a9a945e26b6f0c997d424540cac34ab9ac568f528a4c42a350abf2a6347L101-R101) [[2]](diffhunk://#diff-8e7a1a9a945e26b6f0c997d424540cac34ab9ac568f528a4c42a350abf2a6347L147-R147) [[3]](diffhunk://#diff-9378a200f83a124c88d242691043229bf4614b5d7d51f3516af33a129679569fL42-R42) [[4]](diffhunk://#diff-9378a200f83a124c88d242691043229bf4614b5d7d51f3516af33a129679569fL246-R246) [[5]](diffhunk://#diff-9378a200f83a124c88d242691043229bf4614b5d7d51f3516af33a129679569fL342-R342)
- Example imports of internal components like `Mark` are updated to use `'svelteplot/Mark.svelte'` instead of `'$lib/Mark.svelte'`. [[1]](diffhunk://#diff-a40dc4163053a5b751a53e5a8870476055ef6219785ffd03141961cabc80f55bL348-R348) [[2]](diffhunk://#diff-a40dc4163053a5b751a53e5a8870476055ef6219785ffd03141961cabc80f55bL387-R387) [[3]](diffhunk://#diff-a40dc4163053a5b751a53e5a8870476055ef6219785ffd03141961cabc80f55bL434-R434)

This update ensures that all documentation and examples reflect the correct usage pattern for consumers of the SveltePlot package, reducing confusion and potential import errors.