### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/packages/svelteplot/src/helpers/mergeDeep.ts
+++ b/packages/svelteplot/src/helpers/mergeDeep.ts
@@ -10,7 +10,10 @@ export default function mergeDeep<T extends ObjectType>(
 ): T {
     for (const source of sources) {
         if (isObject(target) && isObject(source)) {
-            for (const key in source) {
+            for (const key of Object.keys(source)) {
+                if (key === '__proto__' || key === 'prototype' || key === 'constructor') {
+                    continue;
+                }
                 if (isObject(source[key])) {
                     if (!target[key]) {
                         Object.assign(target, { [key]: {} });

--- a/packages/svelteplot/src/marks/helpers/Anchor.svelte
+++ b/packages/svelteplot/src/marks/helpers/Anchor.svelte
@@ -32,7 +32,29 @@
 
     let { datum = {} as Datum, options = {}, children }: AnchorProps = $props();
 
-    const href = $derived(resolveProp(options.href, datum, null));
+    const sanitizeHref = (value: unknown): string | null => {
+        if (typeof value !== 'string') return null;
+        const href = value.trim();
+        if (!href) return null;
+        if (
+            href.startsWith('#') ||
+            href.startsWith('/') ||
+            href.startsWith('./') ||
+            href.startsWith('../') ||
+            href.startsWith('?')
+        ) {
+            return href;
+        }
+        const schemeMatch = href.match(/^([a-zA-Z][a-zA-Z\d+.-]*):/);
+        if (!schemeMatch) return href;
+        const protocol = schemeMatch[1].toLowerCase();
+        if (protocol === 'http' || protocol === 'https' || protocol === 'mailto') {
+            return href;
+        }
+        return null;
+    };
+
+    const href = $derived(sanitizeHref(resolveProp(options.href, datum, null)));
     const target = $derived(resolveProp(options.target, datum, null));
     const rel = $derived(resolveProp(options.rel, datum, null));
     const type = $derived(resolveProp(options.type, datum, null));


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `packages/svelteplot/src/helpers/mergeDeep.ts:L9`

The `mergeDeep` function recursively copies keys from untrusted source objects using `for...in` and `Object.assign` without filtering dangerous keys (e.g., `__proto__`, `prototype`, `constructor`) or restricting to own properties. If attacker-controlled input reaches this helper, it may mutate object prototypes (prototype pollution), leading to unexpected behavior or downstream security impact.

## Solution

Iterate with `Object.keys(source)` (or `Object.entries`) instead of `for...in`, check `Object.hasOwn(source, key)`, and explicitly block `__proto__`, `prototype`, and `constructor`. Consider creating targets via `Object.create(null)` for merge internals.

## Changes

- `packages/svelteplot/src/helpers/mergeDeep.ts` (modified)
- `packages/svelteplot/src/marks/helpers/Anchor.svelte` (modified)