### PR TITLE
more logical zero value tooltip position

### DIFF
--- a/packages/svelteplot/src/marks/HTMLTooltip.svelte
+++ b/packages/svelteplot/src/marks/HTMLTooltip.svelte
@@ -99,8 +99,8 @@
 
 <div
     class={['svelteplot-tooltip', { hide: !datum }]}
-    style:left="{tooltipX ? facetOffsetX + projectX('x', plot.scales, tooltipX) : 0}px"
-    style:top="{tooltipY ? facetOffsetY + projectY('y', plot.scales, tooltipY) : 0}px">
+    style:left="{facetOffsetX + projectX('x', plot.scales, tooltipX ?? 0)}px"
+    style:top="{facetOffsetY + projectY('y', plot.scales, tooltipY ?? 0)}px">
     {@render children({ datum: datum as Datum })}
 </div>
 


### PR DESCRIPTION
This PR fixes an issue with the HTMLTooltip position when the X or Y datum value is exactly zero.

Related issue #561 