### PR TITLE
feat(stack): add order value for per-bucket stacking

### DIFF
--- a/packages/svelteplot/src/transforms/stack.test.ts
+++ b/packages/svelteplot/src/transforms/stack.test.ts
@@ -169,6 +169,199 @@ describe('stackY transform', () => {
             { x: 3, y1: 0, y2: 40 }
         ]);
     });
+
+    const crossoverData: DataRecord[] = [
+        { year: 1, category: 'A', value: 100 },
+        { year: 1, category: 'B', value: 1 },
+        { year: 2, category: 'A', value: 1 },
+        { year: 2, category: 'B', value: 100 }
+    ];
+
+    it('order value sorts within each stack group by signed value', () => {
+        const { data: stackedData, ...channels } = stackY<DataRecord>(
+            {
+                data: crossoverData,
+                x: 'year',
+                fill: 'category',
+                y: 'value'
+            },
+            { order: 'value' }
+        );
+
+        const result = stackedData.map((d) => ({
+            x: d[channels.x as string],
+            y1: d[channels.y1 as string],
+            y2: d[channels.y2 as string],
+            fill: d[channels.fill as string]
+        }));
+
+        // output is sorted by original row index
+        expect(result).toEqual([
+            { x: 1, y1: 1, y2: 101, fill: 'A' },
+            { x: 1, y1: 0, y2: 1, fill: 'B' },
+            { x: 2, y1: 0, y2: 1, fill: 'A' },
+            { x: 2, y1: 1, y2: 101, fill: 'B' }
+        ]);
+    });
+
+    it('order value with reverse inverts per-bucket sort', () => {
+        const { data: stackedData, ...channels } = stackY<DataRecord>(
+            {
+                data: crossoverData,
+                x: 'year',
+                fill: 'category',
+                y: 'value'
+            },
+            { order: 'value', reverse: true }
+        );
+
+        const result = stackedData.map((d) => ({
+            x: d[channels.x as string],
+            y1: d[channels.y1 as string],
+            y2: d[channels.y2 as string],
+            fill: d[channels.fill as string]
+        }));
+
+        expect(result).toEqual([
+            { x: 1, y1: 0, y2: 100, fill: 'A' },
+            { x: 1, y1: 100, y2: 101, fill: 'B' },
+            { x: 2, y1: 100, y2: 101, fill: 'A' },
+            { x: 2, y1: 0, y2: 100, fill: 'B' }
+        ]);
+    });
+
+    it('order sum keeps global series order on crossover data', () => {
+        const { data: stackedData, ...channels } = stackY<DataRecord>(
+            {
+                data: crossoverData,
+                x: 'year',
+                fill: 'category',
+                y: 'value'
+            },
+            { order: 'sum' }
+        );
+
+        const result = stackedData.map((d) => ({
+            x: d[channels.x as string],
+            y1: d[channels.y1 as string],
+            y2: d[channels.y2 as string],
+            fill: d[channels.fill as string]
+        }));
+
+        // A has lower total (101) so always below B
+        expect(result).toEqual([
+            { x: 1, y1: 0, y2: 100, fill: 'A' },
+            { x: 1, y1: 100, y2: 101, fill: 'B' },
+            { x: 2, y1: 0, y2: 1, fill: 'A' },
+            { x: 2, y1: 1, y2: 101, fill: 'B' }
+        ]);
+    });
+
+    it('order value stacks negative values with diverging baseline', () => {
+        const negativeData: DataRecord[] = [
+            { year: 1, category: 'A', value: -100 },
+            { year: 1, category: 'B', value: -1 },
+            { year: 1, category: 'C', value: 10 }
+        ];
+
+        const { data: stackedData, ...channels } = stackY<DataRecord>(
+            {
+                data: negativeData,
+                x: 'year',
+                fill: 'category',
+                y: 'value'
+            },
+            { order: 'value' }
+        );
+
+        const result = stackedData.map((d) => ({
+            y1: d[channels.y1 as string],
+            y2: d[channels.y2 as string],
+            fill: d[channels.fill as string]
+        }));
+
+        expect(result).toEqual([
+            { y1: -100, y2: 0, fill: 'A' },
+            { y1: -101, y2: -100, fill: 'B' },
+            { y1: 0, y2: 10, fill: 'C' }
+        ]);
+    });
+
+    it('order value on unit stacking sorts rows within each x bucket', () => {
+        const unitData: DataRecord[] = [
+            { make: 'A', mpg: 100 },
+            { make: 'A', mpg: 1 },
+            { make: 'B', mpg: 50 },
+            { make: 'B', mpg: 5 }
+        ];
+
+        const { data: stackedData, ...channels } = stackY<DataRecord>(
+            { data: unitData, x: 'make', y: 'mpg' },
+            { order: 'value' }
+        );
+
+        const result = stackedData.map((d) => ({
+            x: d[channels.x as string],
+            y1: d[channels.y1 as string],
+            y2: d[channels.y2 as string],
+            mpg: d.mpg
+        }));
+
+        expect(result).toEqual([
+            { x: 'A', y1: 1, y2: 101, mpg: 100 },
+            { x: 'A', y1: 0, y2: 1, mpg: 1 },
+            { x: 'B', y1: 5, y2: 55, mpg: 50 },
+            { x: 'B', y1: 0, y2: 5, mpg: 5 }
+        ]);
+    });
+
+    it('order value rejects non-none offsets', () => {
+        expect(() =>
+            stackY<DataRecord>(
+                { data: crossoverData, x: 'year', fill: 'category', y: 'value' },
+                { order: 'value', offset: 'center' }
+            )
+        ).toThrowError("stack: order 'value' only supports offset 'none'");
+    });
+
+    it('order value respects facet isolation', () => {
+        const facetedCrossover: DataRecord[] = [
+            { year: 1, category: 'A', value: 100, facet: 'X' },
+            { year: 1, category: 'B', value: 1, facet: 'X' },
+            { year: 2, category: 'A', value: 1, facet: 'X' },
+            { year: 2, category: 'B', value: 100, facet: 'X' },
+            { year: 1, category: 'A', value: 50, facet: 'Y' },
+            { year: 1, category: 'B', value: 2, facet: 'Y' }
+        ];
+
+        const { data: stackedData, ...channels } = stackY<DataRecord>(
+            {
+                data: facetedCrossover,
+                x: 'year',
+                fill: 'category',
+                y: 'value',
+                fx: 'facet'
+            },
+            { order: 'value' }
+        );
+
+        const result = stackedData.map((d) => ({
+            x: d[channels.x as string],
+            y1: d[channels.y1 as string],
+            y2: d[channels.y2 as string],
+            fx: d[channels.fx as string],
+            fill: d[channels.fill as string]
+        }));
+
+        expect(result).toEqual([
+            { x: 1, y1: 1, y2: 101, fx: 'X', fill: 'A' },
+            { x: 1, y1: 0, y2: 1, fx: 'X', fill: 'B' },
+            { x: 2, y1: 0, y2: 1, fx: 'X', fill: 'A' },
+            { x: 2, y1: 1, y2: 101, fx: 'X', fill: 'B' },
+            { x: 1, y1: 2, y2: 52, fx: 'Y', fill: 'A' },
+            { x: 1, y1: 0, y2: 2, fx: 'Y', fill: 'B' }
+        ]);
+    });
 });
 
 describe('stackX transform', () => {
@@ -221,6 +414,58 @@ describe('stackX transform', () => {
             { y: 2, x1: 0, x2: 30 },
             { y: 3, x1: 0, x2: NaN },
             { y: 4, x1: 0, x2: 40 }
+        ]);
+    });
+
+    const crossoverData: DataRecord[] = [
+        { year: 1, category: 'A', value: 100 },
+        { year: 1, category: 'B', value: 1 },
+        { year: 2, category: 'A', value: 1 },
+        { year: 2, category: 'B', value: 100 }
+    ];
+
+    it('order value sorts within each stack group along x', () => {
+        const { data: stackedData, ...channels } = stackX<DataRecord>(
+            {
+                data: crossoverData,
+                y: 'year',
+                fill: 'category',
+                x: 'value'
+            },
+            { order: 'value' }
+        );
+
+        const result = stackedData.map((d) => ({
+            y: d[channels.y as string],
+            x1: d[channels.x1 as string],
+            x2: d[channels.x2 as string],
+            fill: d[channels.fill as string]
+        }));
+
+        expect(result).toEqual([
+            { y: 1, x1: 1, x2: 101, fill: 'A' },
+            { y: 1, x1: 0, x2: 1, fill: 'B' },
+            { y: 2, x1: 0, x2: 1, fill: 'A' },
+            { y: 2, x1: 1, x2: 101, fill: 'B' }
+        ]);
+    });
+
+    it('order value preserves undefined values in recordized arrays', () => {
+        const data = [10, 20, undefined, 40] as DataRow[];
+        const { data: stackedData, ...channels } = stackX(recordizeX({ data, x1: 0, x2: 0 }), {
+            order: 'value'
+        });
+        const { y, x1, x2 } = channels;
+        const result = stackedData.map((d) => ({
+            y: d[y as string],
+            x1: d[x1 as string],
+            x2: d[x2 as string]
+        }));
+        expect(result).toEqual([
+            { y: 0, x1: 0, x2: 10 },
+            { y: 1, x1: 0, x2: 20 },
+            { y: 2, x1: 0, x2: NaN },
+            { y: 3, x1: 0, x2: 40 }
         ]);
     });
 });

--- a/packages/svelteplot/src/transforms/stack.test.ts
+++ b/packages/svelteplot/src/transforms/stack.test.ts
@@ -257,34 +257,31 @@ describe('stackY transform', () => {
         ]);
     });
 
-    it('order value stacks negative values with diverging baseline', () => {
+    it('order value matches default d3 baseline for mixed-sign data', () => {
         const negativeData: DataRecord[] = [
             { year: 1, category: 'A', value: -100 },
             { year: 1, category: 'B', value: -1 },
             { year: 1, category: 'C', value: 10 }
         ];
 
-        const { data: stackedData, ...channels } = stackY<DataRecord>(
-            {
-                data: negativeData,
-                x: 'year',
-                fill: 'category',
-                y: 'value'
-            },
-            { order: 'value' }
-        );
+        const args = { data: negativeData, x: 'year', fill: 'category', y: 'value' } as const;
+        const simplify = (stacked: ReturnType<typeof stackY<DataRecord>>) =>
+            stacked.data.map((d) => ({
+                y1: d[stacked.y1 as string],
+                y2: d[stacked.y2 as string],
+                fill: d[stacked.fill as string]
+            }));
 
-        const result = stackedData.map((d) => ({
-            y1: d[channels.y1 as string],
-            y2: d[channels.y2 as string],
-            fill: d[channels.fill as string]
-        }));
+        const d3Stack = simplify(stackY<DataRecord>(args, { order: 'sum' }));
+        const valueStack = simplify(stackY<DataRecord>(args, { order: 'value' }));
 
-        expect(result).toEqual([
+        // same py/ny split as d3 offset none; only sort order within the bucket differs
+        expect(valueStack).toEqual([
             { y1: -100, y2: 0, fill: 'A' },
             { y1: -101, y2: -100, fill: 'B' },
             { y1: 0, y2: 10, fill: 'C' }
         ]);
+        expect(d3Stack.map((d) => d.fill)).toEqual(valueStack.map((d) => d.fill));
     });
 
     it('order value on unit stacking sorts rows within each x bucket', () => {

--- a/packages/svelteplot/src/transforms/stack.test.ts
+++ b/packages/svelteplot/src/transforms/stack.test.ts
@@ -315,13 +315,61 @@ describe('stackY transform', () => {
         ]);
     });
 
-    it('order value rejects non-none offsets', () => {
+    it('order value coerces numeric strings before sorting', () => {
+        const stringData: DataRecord[] = [
+            { year: 1, category: 'A', value: '100' },
+            { year: 1, category: 'B', value: '1' }
+        ];
+
+        const { data: stackedData, ...channels } = stackY<DataRecord>(
+            {
+                data: stringData,
+                x: 'year',
+                fill: 'category',
+                y: 'value'
+            },
+            { order: 'value' }
+        );
+
+        const result = stackedData.map((d) => ({
+            y1: d[channels.y1 as string],
+            y2: d[channels.y2 as string],
+            fill: d[channels.fill as string]
+        }));
+
+        expect(result).toEqual([
+            { y1: 1, y2: 101, fill: 'A' },
+            { y1: 0, y2: 1, fill: 'B' }
+        ]);
+    });
+
+    it('order value rejects unsupported offsets', () => {
         expect(() =>
             stackY<DataRecord>(
                 { data: crossoverData, x: 'year', fill: 'category', y: 'value' },
                 { order: 'value', offset: 'center' }
             )
-        ).toThrowError("stack: order 'value' only supports offset 'none'");
+        ).toThrowError("stack: order 'value' only supports offset 'none' or 'diverging'");
+    });
+
+    it('order value sorts missing values last within a bucket', () => {
+        const data = [10, undefined, 20, undefined] as DataRow[];
+        const { data: stackedData, ...channels } = stackY(
+            recordizeY({ data, x1: null, x2: null, y1: 0, y2: 0 }),
+            { order: 'value' }
+        );
+        const { x, y1, y2 } = channels;
+        const result = stackedData.map((d) => ({
+            x: d[x as string],
+            y1: d[y1 as string],
+            y2: d[y2 as string]
+        }));
+        expect(result).toEqual([
+            { x: 0, y1: 0, y2: 10 },
+            { x: 1, y1: 0, y2: NaN },
+            { x: 2, y1: 0, y2: 20 },
+            { x: 3, y1: 0, y2: NaN }
+        ]);
     });
 
     it('order value respects facet isolation', () => {

--- a/packages/svelteplot/src/transforms/stack.test.ts
+++ b/packages/svelteplot/src/transforms/stack.test.ts
@@ -272,16 +272,16 @@ describe('stackY transform', () => {
                 fill: d[stacked.fill as string]
             }));
 
-        const d3Stack = simplify(stackY<DataRecord>(args, { order: 'sum' }));
         const valueStack = simplify(stackY<DataRecord>(args, { order: 'value' }));
 
-        // same py/ny split as d3 offset none; only sort order within the bucket differs
-        expect(valueStack).toEqual([
-            { y1: -100, y2: 0, fill: 'A' },
-            { y1: -101, y2: -100, fill: 'B' },
-            { y1: 0, y2: 10, fill: 'C' }
-        ]);
-        expect(d3Stack.map((d) => d.fill)).toEqual(valueStack.map((d) => d.fill));
+        const byFill = (rows: typeof valueStack) =>
+            Object.fromEntries(rows.map((d) => [d.fill, d]));
+        // value-sorted bucket with offset none: d3 stackOffsetNone cumulative baseline
+        expect(byFill(valueStack)).toEqual({
+            A: { y1: 0, y2: -100, fill: 'A' },
+            B: { y1: -100, y2: -101, fill: 'B' },
+            C: { y1: -101, y2: -91, fill: 'C' }
+        });
     });
 
     it('order value on unit stacking sorts rows within each x bucket', () => {

--- a/packages/svelteplot/src/transforms/stack.ts
+++ b/packages/svelteplot/src/transforms/stack.ts
@@ -67,6 +67,12 @@ const STACK_ORDER: Record<Exclude<StackOrder, 'value'>, (...args: any[]) => any>
     'inside-out': stackOrderInsideOut
 };
 
+function toStackNumber(value: unknown): number | null | undefined {
+    if (value == null) return value as null | undefined;
+    const n = +value;
+    return Number.isNaN(n) ? NaN : n;
+}
+
 function stackBucketByValue<T extends DataRecord>(
     items: T[],
     byDim: 'x' | 'y',
@@ -75,10 +81,14 @@ function stackBucketByValue<T extends DataRecord>(
     reverse: boolean
 ): T[] {
     const sorted = [...items].sort((a, b) => {
-        const av = a[S[byDim]] as number;
-        const bv = b[S[byDim]] as number;
+        const av = toStackNumber(a[S[byDim]]);
+        const bv = toStackNumber(b[S[byDim]]);
+        const aMissing = av == null || (typeof av === 'number' && Number.isNaN(av));
+        const bMissing = bv == null || (typeof bv === 'number' && Number.isNaN(bv));
+        if (aMissing !== bMissing) return aMissing ? 1 : -1;
+        if (aMissing) return (a[INDEX] as number) - (b[INDEX] as number);
         if (av !== bv) {
-            const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+            const cmp = (av as number) < (bv as number) ? -1 : 1;
             return reverse ? -cmp : cmp;
         }
         return (a[INDEX] as number) - (b[INDEX] as number);
@@ -88,7 +98,7 @@ function stackBucketByValue<T extends DataRecord>(
     let ny = 0;
     const out: T[] = [];
     for (const d of sorted) {
-        const value = d[S[byDim]] as number;
+        const value = toStackNumber(d[S[byDim]]);
         let low: number;
         let high: number;
         if (value == null || (typeof value === 'number' && Number.isNaN(value))) {
@@ -220,28 +230,28 @@ function stackXY<T>(
 
             if (options.order === 'value') {
                 const offset = options.offset ?? 'none';
-                if (offset !== 'none' && offset !== null) {
+                if (offset !== 'none' && offset !== 'diverging') {
                     throw new Error(
-                        `stack: order 'value' only supports offset 'none' (got '${offset}')`
+                        `stack: order 'value' only supports offset 'none' or 'diverging' (got '${offset}')`
                     );
                 }
 
                 for (const [, bucketItems] of groupedBySecondDim) {
                     let itemsToStack: DataRecord[];
                     if (groupBy !== true && hasUniqueGroups) {
-                        const obj: Record<string | number, DataRecord> = {};
+                        const groups = new Map<unknown, DataRecord>();
                         bucketItems.forEach((d) => {
-                            const key = d[GROUP] as string | number;
-                            if (obj[key] == null) obj[key] = { ...d };
+                            const key = d[GROUP];
+                            const existing = groups.get(key);
+                            if (existing == null) groups.set(key, { ...d });
                             else {
-                                obj[key] = {
-                                    ...d,
-                                    [S[byDim]]:
-                                        (obj[key][S[byDim]] as number) + (d[S[byDim]] as number)
-                                };
+                                const sum =
+                                    (toStackNumber(existing[S[byDim]]) as number) +
+                                    (toStackNumber(d[S[byDim]]) as number);
+                                groups.set(key, { ...d, [S[byDim]]: sum });
                             }
                         });
-                        itemsToStack = Object.values(obj);
+                        itemsToStack = [...groups.values()];
                     } else {
                         itemsToStack = [...bucketItems];
                     }

--- a/packages/svelteplot/src/transforms/stack.ts
+++ b/packages/svelteplot/src/transforms/stack.ts
@@ -78,7 +78,8 @@ function stackBucketByValue<T extends DataRecord>(
     byDim: 'x' | 'y',
     byLow: 'x1' | 'y1',
     byHigh: 'x2' | 'y2',
-    reverse: boolean
+    reverse: boolean,
+    offset: 'none' | 'diverging'
 ): T[] {
     const sorted = [...items].sort((a, b) => {
         const av = toStackNumber(a[S[byDim]]);
@@ -94,16 +95,22 @@ function stackBucketByValue<T extends DataRecord>(
         return (a[INDEX] as number) - (b[INDEX] as number);
     });
 
+    const out: T[] = [];
+    let pos = 0;
     let py = 0;
     let ny = 0;
-    const out: T[] = [];
+
     for (const d of sorted) {
         const value = toStackNumber(d[S[byDim]]);
         let low: number;
         let high: number;
         if (value == null || (typeof value === 'number' && Number.isNaN(value))) {
-            low = py;
+            low = offset === 'none' ? pos : py;
             high = NaN;
+        } else if (offset === 'none') {
+            // d3 stackOffsetNone: single cumulative baseline per bucket
+            low = pos;
+            high = pos += value;
         } else if (value >= 0) {
             low = py;
             high = py += value;
@@ -255,13 +262,24 @@ function stackXY<T>(
                     } else {
                         itemsToStack = [...bucketItems];
                     }
+                    const valueOffset = (offset === 'diverging' ? 'diverging' : 'none') as
+                        | 'none'
+                        | 'diverging';
                     out.push(
-                        ...stackBucketByValue(itemsToStack, byDim, byLow, byHigh, options.reverse)
+                        ...stackBucketByValue(
+                            itemsToStack,
+                            byDim,
+                            byLow,
+                            byHigh,
+                            options.reverse,
+                            valueOffset
+                        )
                     );
                 }
             } else {
+                const d3Order = (options.order ?? 'none') as Exclude<StackOrder, 'value'>;
                 const stackOrder = (series: any[]) => {
-                    const f = STACK_ORDER[options.order || 'none'];
+                    const f = STACK_ORDER[d3Order];
                     return options.reverse ? f(series).reverse() : f(series);
                 };
 

--- a/packages/svelteplot/src/transforms/stack.ts
+++ b/packages/svelteplot/src/transforms/stack.ts
@@ -44,7 +44,7 @@ const DEFAULT_STACK_OPTIONS: StackOptions = {
 };
 
 /** the order in which series are stacked */
-export type StackOrder = 'none' | 'appearance' | 'inside-out' | 'sum';
+export type StackOrder = 'none' | 'appearance' | 'inside-out' | 'sum' | 'value';
 /** the offset method used to position stacked values */
 export type StackOffset = 'none' | 'wiggle' | 'center' | 'normalize' | 'diverging';
 
@@ -60,14 +60,51 @@ export type StackOptions =
       }
     | false;
 
-const STACK_ORDER: Record<StackOrder, (...args: any[]) => any> = {
-    // null
-    // TODO: value: ,
+const STACK_ORDER: Record<Exclude<StackOrder, 'value'>, (...args: any[]) => any> = {
     none: stackOrderNone,
     sum: stackOrderAscending,
     appearance: stackOrderAppearance,
     'inside-out': stackOrderInsideOut
 };
+
+function stackBucketByValue<T extends DataRecord>(
+    items: T[],
+    byDim: 'x' | 'y',
+    byLow: 'x1' | 'y1',
+    byHigh: 'x2' | 'y2',
+    reverse: boolean
+): T[] {
+    const sorted = [...items].sort((a, b) => {
+        const av = a[S[byDim]] as number;
+        const bv = b[S[byDim]] as number;
+        if (av !== bv) {
+            const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+            return reverse ? -cmp : cmp;
+        }
+        return (a[INDEX] as number) - (b[INDEX] as number);
+    });
+
+    let py = 0;
+    let ny = 0;
+    const out: T[] = [];
+    for (const d of sorted) {
+        const value = d[S[byDim]] as number;
+        let low: number;
+        let high: number;
+        if (value == null || (typeof value === 'number' && Number.isNaN(value))) {
+            low = py;
+            high = NaN;
+        } else if (value >= 0) {
+            low = py;
+            high = py += value;
+        } else {
+            high = ny;
+            low = ny += value;
+        }
+        out.push({ ...d, [S[byLow]]: low, [S[byHigh]]: high } as T);
+    }
+    return out;
+}
 
 const STACK_OFFSET: Record<StackOffset, ((...args: any[]) => any) | null> = {
     none: null,
@@ -181,35 +218,69 @@ function stackXY<T>(
                 keys = Array.from(keySet);
             }
 
-            const stackOrder = (series: any[]) => {
-                const f = STACK_ORDER[options.order || 'none'];
-                return options.reverse ? f(series).reverse() : f(series);
-            };
+            if (options.order === 'value') {
+                const offset = options.offset ?? 'none';
+                if (offset !== 'none' && offset !== null) {
+                    throw new Error(
+                        `stack: order 'value' only supports offset 'none' (got '${offset}')`
+                    );
+                }
 
-            // now stack the values for each index
-            const series = stack()
-                .order(stackOrder as any)
-                // Wiggle requires consistent series identities; fall back to 'center' for unit stacking
-                .offset(
-                    (groupBy === true && options.offset === 'wiggle'
-                        ? STACK_OFFSET['center']
-                        : STACK_OFFSET[options.offset ?? 'none']) as any
-                )
-                .keys(keys)
-                .value((d: any, key: any, _i: any, _data: any) => {
-                    return d[key]?.v == null ? undefined : d[key]?.v;
-                })(stackData);
+                for (const [, bucketItems] of groupedBySecondDim) {
+                    let itemsToStack: DataRecord[];
+                    if (groupBy !== true && hasUniqueGroups) {
+                        const obj: Record<string | number, DataRecord> = {};
+                        bucketItems.forEach((d) => {
+                            const key = d[GROUP] as string | number;
+                            if (obj[key] == null) obj[key] = { ...d };
+                            else {
+                                obj[key] = {
+                                    ...d,
+                                    [S[byDim]]:
+                                        (obj[key][S[byDim]] as number) + (d[S[byDim]] as number)
+                                };
+                            }
+                        });
+                        itemsToStack = Object.values(obj);
+                    } else {
+                        itemsToStack = [...bucketItems];
+                    }
+                    out.push(
+                        ...stackBucketByValue(itemsToStack, byDim, byLow, byHigh, options.reverse)
+                    );
+                }
+            } else {
+                const stackOrder = (series: any[]) => {
+                    const f = STACK_ORDER[options.order || 'none'];
+                    return options.reverse ? f(series).reverse() : f(series);
+                };
 
-            // and combine it all back into a flat array
-            const newData = (series as any)
-                .flatMap((s: any) => s.map((d: any) => [d[0], d[1], d.data[s.key]?.i]))
-                .filter((d: any) => d[2] !== undefined)
-                .map((d: any) => ({ [S[byLow]]: d[0], [S[byHigh]]: d[1], ...resolvedData[d[2]] }));
+                // now stack the values for each index
+                const series = stack()
+                    .order(stackOrder as any)
+                    // Wiggle requires consistent series identities; fall back to 'center' for unit stacking
+                    .offset(
+                        (groupBy === true && options.offset === 'wiggle'
+                            ? STACK_OFFSET['center']
+                            : STACK_OFFSET[options.offset ?? 'none']) as any
+                    )
+                    .keys(keys)
+                    .value((d: any, key: any, _i: any, _data: any) => {
+                        return d[key]?.v == null ? undefined : d[key]?.v;
+                    })(stackData);
 
-            out.push(...newData);
+                // and combine it all back into a flat array
+                const newData = (series as any)
+                    .flatMap((s: any) => s.map((d: any) => [d[0], d[1], d.data[s.key]?.i]))
+                    .filter((d: any) => d[2] !== undefined)
+                    .map((d: any) => ({
+                        [S[byLow]]: d[0],
+                        [S[byHigh]]: d[1],
+                        ...resolvedData[d[2]]
+                    }));
 
-            // which we then add to the output data
-            // out.push(...newData);
+                out.push(...newData);
+            }
         }
 
         return {

--- a/src/routes/api/transforms/+page.md
+++ b/src/routes/api/transforms/+page.md
@@ -764,6 +764,7 @@ the order in which series are stacked
 - `appearance`
 - `inside-out`
 - `sum`
+- `value`
 
 ## stackY
 

--- a/src/routes/marks/area/+page.md
+++ b/src/routes/marks/area/+page.md
@@ -240,7 +240,7 @@ To create a stacked area chart you can use the implicit [stackY](/transforms/sta
 
 You can control the stacking for the implicit [stackY](/transforms/stack) transform using the `stack` options:
 
-- `order` - can be one of `none`, `appearance`, `inside-out`, or `sum`.
+- `order` - can be one of `none`, `appearance`, `inside-out`, `sum`, or `value`.
 - `reverse` - for reversing the order
 - `offset`
 
@@ -266,7 +266,13 @@ You can control the stacking for the implicit [stackY](/transforms/stack) transf
 <Select label="curve" options={CURVES} bind:value={curve} />
 <Select
     label="order"
-    options={['none', 'appearance', 'inside-out', 'sum']}
+    options={[
+        'none',
+        'appearance',
+        'inside-out',
+        'sum',
+        'value'
+    ]}
     bind:value={order} />
 <Plot>
     <AreaY


### PR DESCRIPTION
## Summary

- Implements `stack.order: 'value'` (Observable Plot parity): sorts rows within each stack group by signed magnitude
- Manual per-bucket stacking path; `offset: 'none'` / `'diverging'` only (other offsets throw)
- Closes TODO in `stack.ts`

## Tests

Crossover, reverse, stackX, facets, negatives, unit stacking, numeric strings, missing values

## Docs

- API `StackOrder` updated
- Area mark docs: `value` in order list + first interactive select (not streamgraph select — wiggle offset incompatible)