### PR TITLE
fix(scales): honor sort on non-first layers for ordinal domains

### DIFF
--- a/packages/svelteplot/src/helpers/scales.test.ts
+++ b/packages/svelteplot/src/helpers/scales.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { inferScaleType, looksLikeANumber } from './scales.js';
+import { scalePoint } from 'd3-scale';
+import { createScale, inferScaleType, looksLikeANumber } from './scales.js';
+import { IS_SORTED } from '../transforms/sort.js';
+import type { Mark } from '../types/mark.js';
+import type { GenericMarkOptions } from '../types/index.js';
 
 const STRINGS = ['foo', 'bar', 'baz'];
 const DATES = [new Date(), new Date()];
@@ -47,6 +51,66 @@ describe('inferScaleType', () => {
     });
     it('infers time scale when nice is set on date data', () => {
         expect(inferScaleType('x', DATES, new Set(['tickY']), { nice: true })).toBe('time');
+    });
+});
+
+const plotDefaults = {} as any;
+const basePlotOptions = {
+    implicitScales: true,
+    sortOrdinalDomains: true
+} as any;
+
+function mockMark(
+    data: Record<string, unknown>[],
+    options: GenericMarkOptions & { [IS_SORTED]?: unknown }
+): Mark<GenericMarkOptions> {
+    return {
+        id: Symbol(),
+        type: 'dot',
+        channels: ['x', 'y'],
+        scales: new Set(['x', 'y']),
+        data,
+        options
+    };
+}
+
+describe('createScale sorted ordinal domain', () => {
+    it('uses the first sorted mark bound to the scale for domain order', () => {
+        const unsorted = mockMark(
+            [
+                { label: 'Zulu', value: 300 },
+                { label: 'Alpha', value: 100 },
+                { label: 'Beta', value: 200 }
+            ],
+            { x: 'value', y: 'label' }
+        );
+        const sorted = mockMark(
+            [
+                { label: 'Zulu', value: 300 },
+                { label: 'Beta', value: 200 },
+                { label: 'Alpha', value: 100 }
+            ],
+            { x: 'value', y: 'label', [IS_SORTED]: { channel: '-x' } }
+        );
+
+        const scale = createScale(
+            'y',
+            {
+                scale: ({ domain, plotHeight }: any) =>
+                    scalePoint()
+                        .domain(domain)
+                        .range([plotHeight, 0])
+            },
+            [unsorted, sorted],
+            basePlotOptions,
+            100,
+            100,
+            false,
+            plotDefaults
+        );
+
+        // y domains are reversed from value order
+        expect(scale.domain).toEqual(['Alpha', 'Beta', 'Zulu']);
     });
 });
 

--- a/packages/svelteplot/src/helpers/scales.ts
+++ b/packages/svelteplot/src/helpers/scales.ts
@@ -165,6 +165,59 @@ export function computeScales(
     return { x, y, r, color, opacity, length, symbol, fx, fy, projection } as unknown as PlotScales;
 }
 
+function channelAccessorForScale(
+    channel: ScaledChannelName,
+    mark: Mark<GenericMarkOptions>,
+    scaleName: ScaleName,
+    plotOptions: ResolvedPlotOptions,
+    scaleOptions: Partial<ScaleOptions>
+): ChannelAccessor | null {
+    if (!mark.data.length || mark.options[channel] === undefined) return null;
+
+    const channelOptions = isDataRecord(mark.options[channel])
+        ? mark.options[channel]
+        : { value: mark.options[channel], scale: CHANNEL_SCALE[channel] };
+
+    const useScale =
+        channelOptions.scale === scaleName &&
+        (plotOptions.implicitScales || (scaleOptions as any).scale) &&
+        typeof channelOptions.value !== 'undefined';
+
+    return useScale && channelOptions.value != null ? channelOptions.value : null;
+}
+
+const SCALE_CHANNELS: Record<'x' | 'y', ScaledChannelName[]> = {
+    x: ['x', 'x1', 'x2'],
+    y: ['y', 'y1', 'y2']
+};
+
+/** Collect unique ordinal scale values in a sorted mark's data order. */
+function collectSortedDomainOrder(
+    mark: Mark<GenericMarkOptions>,
+    scaleName: 'x' | 'y',
+    plotOptions: ResolvedPlotOptions,
+    scaleOptions: Partial<ScaleOptions>
+): RawValue[] {
+    let accessor: ChannelAccessor | null = null;
+    for (const channel of SCALE_CHANNELS[scaleName]) {
+        accessor = channelAccessorForScale(channel, mark, scaleName, plotOptions, scaleOptions);
+        if (accessor) break;
+    }
+    if (!accessor) return [];
+
+    const order: RawValue[] = [];
+    const seen = new Set<RawValue>();
+    for (const datum of mark.data) {
+        const value = resolveProp(accessor, datum);
+        if (value == null) continue;
+        if (!seen.has(value)) {
+            seen.add(value);
+            order.push(value);
+        }
+    }
+    return order;
+}
+
 export function createScale(
     name: ScaleName,
     scaleOptions: Partial<ScaleOptions>,
@@ -201,6 +254,7 @@ export function createScale(
     const propNames = new Set<string>();
     const uniqueScaleProps = new Set<string | ChannelAccessor>();
     let sortOrdinalDomain = plotOptions.sortOrdinalDomains ?? true;
+    let sortedDomainMark: Mark<GenericMarkOptions> | null = null;
     for (const mark of marks) {
         // we only sort the scale domain alphabetically, if none of the
         // marks that map to it are using the `sort` transform. Note that
@@ -208,7 +262,16 @@ export function createScale(
         // since the explicit sort transforms like shuffle will set the
         // sort channel to null to we know that there's an explicit order
         if ((name === 'x' || name === 'y') && mark.options[IS_SORTED] != undefined) {
-            sortOrdinalDomain = false;
+            const sortedOrder = collectSortedDomainOrder(
+                mark,
+                name,
+                plotOptions,
+                scaleOptions
+            );
+            if (sortedOrder.length > 0) {
+                sortOrdinalDomain = false;
+                if (!sortedDomainMark) sortedDomainMark = mark;
+            }
         }
 
         for (const channel of mark.channels) {
@@ -324,7 +387,7 @@ export function createScale(
 
     // construct domain from data values
     // For facet scales (fx/fy), null is a valid grouping category (e.g. penguins with sex=null)
-    const valueArr = [...dataValues.values(), ...(scaleOptions.domain || [])].filter(
+    let valueArr = [...dataValues.values(), ...(scaleOptions.domain || [])].filter(
         (d) => d != null || name === 'fx' || name === 'fy'
     );
 
@@ -342,6 +405,22 @@ export function createScale(
 
     if (isOrdinal && sortOrdinalDomain) {
         valueArr.sort(ascending as any);
+    } else if (
+        isOrdinal &&
+        !scaleOptions.domain &&
+        sortedDomainMark &&
+        (name === 'x' || name === 'y')
+    ) {
+        const sortedDomainOrder = collectSortedDomainOrder(
+            sortedDomainMark,
+            name,
+            plotOptions,
+            scaleOptions
+        );
+        if (sortedDomainOrder.length > 0) {
+            const seen = new Set(sortedDomainOrder);
+            valueArr = [...sortedDomainOrder, ...valueArr.filter((v) => !seen.has(v))];
+        }
     }
 
     const valueArray =

--- a/packages/svelteplot/tests/lineDotSort.test.svelte
+++ b/packages/svelteplot/tests/lineDotSort.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import { Dot, Line, Plot } from 'svelteplot';
+    import type { ComponentProps } from 'svelte';
+
+    interface Props {
+        plotArgs?: ComponentProps<typeof Plot>;
+        lineArgs: ComponentProps<typeof Line>;
+        dotArgs: ComponentProps<typeof Dot>;
+    }
+
+    let { plotArgs = {}, lineArgs, dotArgs }: Props = $props();
+</script>
+
+<Plot width={200} height={200} axes={true} {...plotArgs}>
+    <Line {...lineArgs} />
+    <Dot {...dotArgs} />
+</Plot>

--- a/packages/svelteplot/tests/lineDotSort.test.svelte.ts
+++ b/packages/svelteplot/tests/lineDotSort.test.svelte.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+// @ts-ignore - svelte-check errors on .svelte imports, tsc does not
+import LineDotSortTest from './lineDotSort.test.svelte';
+
+const languages = [
+    { Language: 'Zulu', speakers: 300 },
+    { Language: 'Alpha', speakers: 100 },
+    { Language: 'Beta', speakers: 200 }
+];
+
+/** Y-axis tick order when domain follows descending speakers (y scale reverses domain). */
+const speakersDescTicks = ['Alpha', 'Beta', 'Zulu'];
+/** Y-axis tick order when domain is alphabetical (y scale reverses domain). */
+const alphaTicks = ['Zulu', 'Beta', 'Alpha'];
+
+function yTickTexts(container: HTMLElement) {
+    return Array.from(container.querySelectorAll('svg g.axis-y .tick text')).map(
+        (t) => t.textContent
+    );
+}
+
+describe('sort on second layer (issue #19)', () => {
+    it('dot sort on second layer orders the shared y domain', () => {
+        const { container } = render(LineDotSortTest, {
+            props: {
+                lineArgs: {
+                    data: languages,
+                    x: 'speakers',
+                    y: 'Language',
+                    opacity: 0.5
+                },
+                dotArgs: {
+                    data: languages,
+                    x: 'speakers',
+                    y: 'Language',
+                    fill: 'steelblue',
+                    sort: { channel: '-x' }
+                }
+            }
+        });
+
+        expect(yTickTexts(container)).toEqual(speakersDescTicks);
+        expect(yTickTexts(container)).not.toEqual(alphaTicks);
+    });
+
+    it('line sort on first layer still orders the shared y domain', () => {
+        const { container } = render(LineDotSortTest, {
+            props: {
+                lineArgs: {
+                    data: languages,
+                    x: 'speakers',
+                    y: 'Language',
+                    sort: { channel: '-x' },
+                    opacity: 0.5
+                },
+                dotArgs: {
+                    data: languages,
+                    x: 'speakers',
+                    y: 'Language',
+                    fill: 'steelblue'
+                }
+            }
+        });
+
+        expect(yTickTexts(container)).toEqual(speakersDescTicks);
+        expect(yTickTexts(container)).not.toEqual(alphaTicks);
+    });
+});


### PR DESCRIPTION
Fixes #19. Sorted marks now define shared ordinal domain order even when they are not the first layer.