### PR TITLE
fix(svelteplot): auto margins immune to ancestor CSS transform scale

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,11 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
+            - name: Install Playwright (svelteplot browser tests)
+              run: pnpm --filter svelteplot exec playwright install --with-deps chromium
+
             - name: Run Vitest tests
               run: pnpm test
+
+            - name: Run svelteplot browser tests
+              run: pnpm --filter svelteplot test:browser

--- a/packages/svelteplot/package.json
+++ b/packages/svelteplot/package.json
@@ -57,6 +57,7 @@
     "scripts": {
         "prepack": "npx svelte-package --input src && node scripts/fix-js-imports.js dist",
         "test": "vitest run",
+        "test:browser": "vitest run --config vitest.browser.config.js",
         "test:watch": "vitest"
     },
     "dependencies": {
@@ -99,7 +100,10 @@
         "@types/topojson-client": "^3.1.5",
         "@testing-library/svelte": "^5.3.1",
         "@testing-library/user-event": "^14.6.1",
+        "@vitest/browser-playwright": "4.1.4",
+        "vitest-browser-svelte": "^2.1.1",
         "jsdom": "^27.4.0",
+        "playwright": "^1.52.0",
         "resize-observer-polyfill": "^1.5.1",
         "svelte": "5",
         "typescript": "^5.9.3",

--- a/packages/svelteplot/src/helpers/measureSvgTextLayoutExtent.ts
+++ b/packages/svelteplot/src/helpers/measureSvgTextLayoutExtent.ts
@@ -1,0 +1,113 @@
+type BBox = { x: number; y: number; width: number; height: number };
+
+type AffineMatrix = {
+    a: number;
+    b: number;
+    c: number;
+    d: number;
+    e: number;
+    f: number;
+};
+
+function getTextBBox(text: SVGTextElement): BBox | null | 'error' {
+    if (typeof text.getBBox !== 'function') {
+        return null;
+    }
+
+    try {
+        const bbox = text.getBBox();
+        if (bbox.width > 0 || bbox.height > 0) {
+            return { x: bbox.x, y: bbox.y, width: bbox.width, height: bbox.height };
+        }
+
+        const tspans = text.querySelectorAll('tspan');
+        if (tspans.length === 0) return null;
+
+        let minX = Infinity;
+        let minY = Infinity;
+        let maxX = -Infinity;
+        let maxY = -Infinity;
+
+        for (const tspan of tspans) {
+            const tb = (tspan as SVGTSpanElement).getBBox();
+            if (tb.width === 0 && tb.height === 0) continue;
+            minX = Math.min(minX, tb.x);
+            minY = Math.min(minY, tb.y);
+            maxX = Math.max(maxX, tb.x + tb.width);
+            maxY = Math.max(maxY, tb.y + tb.height);
+        }
+
+        if (!Number.isFinite(minX)) return null;
+        return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+    } catch {
+        return 'error';
+    }
+}
+
+function transformPoint(matrix: AffineMatrix, x: number, y: number): [number, number] {
+    return [
+        matrix.a * x + matrix.c * y + matrix.e,
+        matrix.b * x + matrix.d * y + matrix.f
+    ];
+}
+
+function axisAlignedExtent(
+    bbox: BBox,
+    matrix: AffineMatrix | null,
+    axis: 'width' | 'height'
+): number {
+    const corners: [number, number][] = [
+        [bbox.x, bbox.y],
+        [bbox.x + bbox.width, bbox.y],
+        [bbox.x, bbox.y + bbox.height],
+        [bbox.x + bbox.width, bbox.y + bbox.height]
+    ];
+
+    const points = matrix
+        ? corners.map(([x, y]) => transformPoint(matrix, x, y))
+        : corners;
+
+    if (axis === 'width') {
+        const xs = points.map(([x]) => x);
+        return Math.max(...xs) - Math.min(...xs);
+    }
+
+    const ys = points.map(([, y]) => y);
+    return Math.max(...ys) - Math.min(...ys);
+}
+
+function matrixFromConsolidated(consolidated: { matrix: AffineMatrix } | null): AffineMatrix | null {
+    if (!consolidated?.matrix) return null;
+    const { a, b, c, d, e, f } = consolidated.matrix;
+    if ([a, b, c, d, e, f].every((n) => typeof n === 'number' && Number.isFinite(n))) {
+        return { a, b, c, d, e, f };
+    }
+    return null;
+}
+
+function getLocalTransformMatrix(text: SVGTextElement): AffineMatrix | null {
+    const consolidated = text.transform?.baseVal?.consolidate?.() ?? null;
+    return matrixFromConsolidated(consolidated as { matrix: AffineMatrix } | null);
+}
+
+export function measureSvgTextLayoutExtent(
+    text: SVGTextElement,
+    axis: 'width' | 'height'
+): number {
+    const bbox = getTextBBox(text);
+    if (bbox === 'error') {
+        return 0;
+    }
+    if (bbox) {
+        const matrix = getLocalTransformMatrix(text);
+        return axisAlignedExtent(bbox, matrix, axis);
+    }
+
+    // @vitest-environment jsdom — getBBox unavailable; last-resort viewport geometry
+    try {
+        const rect = text.getBoundingClientRect();
+        return axis === 'width' ? rect.width : rect.height;
+    } catch {
+        return 0;
+    }
+}

--- a/packages/svelteplot/src/marks/helpers/BaseAxisX.svelte
+++ b/packages/svelteplot/src/marks/helpers/BaseAxisX.svelte
@@ -16,6 +16,7 @@
     import { resolveProp, resolveStyles } from '../../helpers/resolve.js';
     import { max } from 'd3-array';
     import { randomId, testFilter } from '../../helpers/index.js';
+    import { measureSvgTextLayoutExtent } from '../../helpers/measureSvgTextLayoutExtent.js';
     import { INDEX } from 'svelteplot/constants';
     import { RAW_VALUE } from 'svelteplot/transforms/recordize';
     import wordwrap from 'svelteplot/helpers/wordwrap';
@@ -147,7 +148,7 @@
                             return 0;
                         if (tick.hidden || !testFilter(tick, options)) return 0;
                         if (tickTextElements[i])
-                            return tickTextElements[i].getBoundingClientRect().height;
+                            return measureSvgTextLayoutExtent(tickTextElements[i], 'height');
                         return 0;
                     }) as number[]
                 ) ?? 0

--- a/packages/svelteplot/src/marks/helpers/BaseAxisY.svelte
+++ b/packages/svelteplot/src/marks/helpers/BaseAxisY.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { getContext, untrack } from 'svelte';
     import { randomId, testFilter } from '../../helpers/index.js';
+    import { measureSvgTextLayoutExtent } from '../../helpers/measureSvgTextLayoutExtent.js';
     import { resolveProp, resolveStyles } from '../../helpers/resolve.js';
     import { max } from 'd3-array';
     import type {
@@ -119,7 +120,8 @@
                         )
                             return 0;
                         if (tick.hidden || !testFilter(tick, options)) return 0;
-                        if (tickTexts[i]) return tickTexts[i].getBoundingClientRect().width;
+                        if (tickTexts[i])
+                            return measureSvgTextLayoutExtent(tickTexts[i], 'width');
                         return 0;
                     }) as number[]
                 ) ?? 0

--- a/packages/svelteplot/tests/css-transform-margins.browser.test.svelte.ts
+++ b/packages/svelteplot/tests/css-transform-margins.browser.test.svelte.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+// @ts-ignore
+import CssTransformMarginsTest from './css-transform-margins.test.svelte';
+
+async function readMargins(container: HTMLElement) {
+    const marginLeft = Number(
+        container.querySelector('[data-testid="margin-probe-left"]')?.textContent
+    );
+    const marginBottom = Number(
+        container.querySelector('[data-testid="margin-probe-bottom"]')?.textContent
+    );
+    return { marginLeft, marginBottom };
+}
+
+async function resizeChart(
+    component: { rerender: (props: Record<string, unknown>) => Promise<void> },
+    from: number,
+    to: number,
+    step = 3
+) {
+    for (let w = from + step; w <= to; w += step) {
+        await component.rerender({ width: w });
+        await new Promise((r) => setTimeout(r, 0));
+    }
+}
+
+describe('css transform auto margins (browser)', () => {
+    it('B1: survives resize churn under scale(1.3) without effect_update_depth_exceeded', async () => {
+        const errors: string[] = [];
+        const onError = (event: Event) => {
+            errors.push((event as ErrorEvent).message ?? String(event));
+        };
+        window.addEventListener('error', onError);
+
+        const screen = await render(CssTransformMarginsTest, {
+            props: { width: 400, scale: 1.3 }
+        });
+        await resizeChart(screen, 400, 500);
+        window.removeEventListener('error', onError);
+
+        expect(errors.some((e) => e.includes('effect_update_depth_exceeded'))).toBe(false);
+    });
+
+    it('B4: scale-invariant margins between scale(1) and scale(1.3)', async () => {
+        const scaled = await render(CssTransformMarginsTest, {
+            props: { width: 400, scale: 1.3 }
+        });
+        await resizeChart(scaled, 400, 500);
+        const scaledMargins = await readMargins(scaled.container);
+
+        const unscaled = await render(CssTransformMarginsTest, {
+            props: { width: 400, scale: 1 }
+        });
+        await resizeChart(unscaled, 400, 500);
+        const unscaledMargins = await readMargins(unscaled.container);
+
+        expect(Math.abs(scaledMargins.marginLeft - unscaledMargins.marginLeft)).toBeLessThanOrEqual(
+            1
+        );
+        expect(
+            Math.abs(scaledMargins.marginBottom - unscaledMargins.marginBottom)
+        ).toBeLessThanOrEqual(1);
+    });
+
+    it('B2: scale-invariant margins with tickRotate 0', async () => {
+        const screen = await render(CssTransformMarginsTest, {
+            props: { width: 400, scale: 1.3, tickRotate: 0 }
+        });
+        await resizeChart(screen, 400, 500);
+        const { marginBottom } = await readMargins(screen.container);
+        expect(marginBottom).toBeGreaterThan(5);
+    });
+
+    it('B3: scale-invariant margins with tickRotate 45', async () => {
+        const rotatedAtOne = await render(CssTransformMarginsTest, {
+            props: { width: 400, scale: 1, tickRotate: 45 }
+        });
+        await resizeChart(rotatedAtOne, 400, 500);
+        const atOne = await readMargins(rotatedAtOne.container);
+
+        const rotatedAtScale = await render(CssTransformMarginsTest, {
+            props: { width: 400, scale: 1.3, tickRotate: 45 }
+        });
+        await resizeChart(rotatedAtScale, 400, 500);
+        const atScale = await readMargins(rotatedAtScale.container);
+
+        expect(Math.abs(atScale.marginLeft - atOne.marginLeft)).toBeLessThanOrEqual(1);
+        expect(Math.abs(atScale.marginBottom - atOne.marginBottom)).toBeLessThanOrEqual(1);
+
+        const unrotated = await render(CssTransformMarginsTest, {
+            props: { width: 400, scale: 1, tickRotate: 0 }
+        });
+        await resizeChart(unrotated, 400, 500);
+        const baseline = await readMargins(unrotated.container);
+
+        expect(atOne.marginBottom).toBeGreaterThan(baseline.marginBottom);
+    });
+});

--- a/packages/svelteplot/tests/css-transform-margins.test.svelte
+++ b/packages/svelteplot/tests/css-transform-margins.test.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import { Plot, AreaY } from 'svelteplot';
+    import type { ComponentProps } from 'svelte';
+
+    interface Props {
+        width?: number;
+        scale?: number;
+        tickRotate?: number;
+    }
+
+    let { width = 400, scale = 1.3, tickRotate = 0 }: Props = $props();
+
+    const areaArgs: ComponentProps<typeof AreaY> = {
+        data: [
+            { date: new Date('2020-01-01'), value: 10 },
+            { date: new Date('2020-06-01'), value: 50 },
+            { date: new Date('2021-01-01'), value: 30 }
+        ],
+        x: 'date',
+        y: 'value'
+    };
+</script>
+
+<div style="transform: scale({scale})">
+    <Plot {width} height={200} x={{ type: 'utc', tickRotate }} y={{ domain: [0, 100] }}>
+        {#snippet children({ options })}
+            <text data-testid="margin-probe-left" x={0} y={0}>{options.marginLeft}</text>
+            <text data-testid="margin-probe-bottom" x={0} y={12}>{options.marginBottom}</text>
+            <AreaY {...areaArgs} />
+        {/snippet}
+    </Plot>
+</div>

--- a/packages/svelteplot/tests/css-transform-margins.test.svelte.ts
+++ b/packages/svelteplot/tests/css-transform-margins.test.svelte.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+// @ts-ignore - svelte-check errors on .svelte imports, tsc does not
+import CssTransformMarginsTest from './css-transform-margins.test.svelte';
+
+const MOCK_BBOX = { x: 0, y: 0, width: 30, height: 12 };
+const SCALE = 1.3;
+
+function installGeometryMocks() {
+    const textProto = Object.getPrototypeOf(
+        document.createElementNS('http://www.w3.org/2000/svg', 'text')
+    ) as SVGTextElement;
+
+    const originalGbcr = Element.prototype.getBoundingClientRect;
+    const originalGetBBox = (textProto as { getBBox?: () => DOMRect }).getBBox;
+
+    Element.prototype.getBoundingClientRect = function (this: Element) {
+        const isSvgText =
+            this.namespaceURI === 'http://www.w3.org/2000/svg' && this.localName === 'text';
+        if (isSvgText) {
+            const bbox =
+                typeof (this as SVGTextElement).getBBox === 'function'
+                    ? (this as SVGTextElement).getBBox()
+                    : { width: MOCK_BBOX.width, height: MOCK_BBOX.height };
+            return {
+                x: 0,
+                y: 0,
+                width: bbox.width * SCALE,
+                height: bbox.height * SCALE,
+                top: 0,
+                left: 0,
+                right: bbox.width * SCALE,
+                bottom: bbox.height * SCALE,
+                toJSON: () => ({})
+            } as DOMRect;
+        }
+        return originalGbcr.call(this);
+    };
+
+    textProto.getBBox = function () {
+        return MOCK_BBOX as DOMRect;
+    };
+
+    return () => {
+        Element.prototype.getBoundingClientRect = originalGbcr;
+        if (originalGetBBox) {
+            textProto.getBBox = originalGetBBox;
+        } else {
+            delete (textProto as { getBBox?: () => DOMRect }).getBBox;
+        }
+    };
+}
+
+describe('css transform auto margins', () => {
+    let restoreMocks: () => void;
+    const errors: string[] = [];
+
+    const onError = (event: Event) => {
+        const msg = (event as ErrorEvent).message ?? String(event);
+        errors.push(msg);
+    };
+
+    beforeEach(() => {
+        restoreMocks = installGeometryMocks();
+        errors.length = 0;
+        window.addEventListener('error', onError);
+    });
+
+    afterEach(() => {
+        window.removeEventListener('error', onError);
+        restoreMocks();
+    });
+
+    it(
+        'uses unscaled SVG layout units for auto margins under mocked CSS scale',
+        async () => {
+        const { container, rerender } = render(CssTransformMarginsTest, { props: { width: 300 } });
+
+        for (let w = 303; w <= 500; w += 3) {
+            await rerender({ width: w });
+            await new Promise((r) => setTimeout(r, 0));
+        }
+
+        const marginBottom = Number(
+            container.querySelector('[data-testid="margin-probe-bottom"]')?.textContent
+        );
+        const marginLeft = Number(
+            container.querySelector('[data-testid="margin-probe-left"]')?.textContent
+        );
+
+        // ceil(12) + tickPadding(3) + tickSize(6) = 21; inflated gbcr yields 25
+        expect(marginBottom).toBe(21);
+        expect(marginBottom).toBeLessThan(25);
+        expect(marginLeft).toBeGreaterThan(0);
+
+        expect(errors.some((e) => e.includes('effect_update_depth_exceeded'))).toBe(false);
+        },
+        15000
+    );
+});

--- a/packages/svelteplot/tests/measureSvgTextLayoutExtent.test.ts
+++ b/packages/svelteplot/tests/measureSvgTextLayoutExtent.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { measureSvgTextLayoutExtent } from '../src/helpers/measureSvgTextLayoutExtent.js';
+
+const SCALE = 1.3;
+const BBOX = { x: 0, y: 0, width: 30, height: 12 };
+
+function createTextElement(): SVGTextElement {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    svg.appendChild(text);
+    document.body.appendChild(svg);
+    return text;
+}
+
+describe('measureSvgTextLayoutExtent', () => {
+    let text: SVGTextElement;
+
+    beforeEach(() => {
+        text = createTextElement();
+        text.getBBox = vi.fn().mockReturnValue(BBOX as DOMRect);
+        vi.spyOn(text, 'getBoundingClientRect').mockReturnValue({
+            x: 0,
+            y: 0,
+            width: BBOX.width * SCALE,
+            height: BBOX.height * SCALE,
+            top: 0,
+            left: 0,
+            right: BBOX.width * SCALE,
+            bottom: BBOX.height * SCALE,
+            toJSON: () => ({})
+        } as DOMRect);
+    });
+
+    afterEach(() => {
+        text.parentElement?.remove();
+        vi.restoreAllMocks();
+    });
+
+    it('T1: returns unscaled user-space dimension when gbcr is inflated', () => {
+        expect(measureSvgTextLayoutExtent(text, 'width')).toBe(30);
+        expect(measureSvgTextLayoutExtent(text, 'height')).toBe(12);
+    });
+
+    it('T3: returns raw bbox height when tick rotation is zero', () => {
+        expect(measureSvgTextLayoutExtent(text, 'height')).toBe(BBOX.height);
+    });
+
+    it('T2: measures rotated tick height from bbox corners and local transform', () => {
+        const rad = (45 * Math.PI) / 180;
+        const cos = Math.cos(rad);
+        const sin = Math.sin(rad);
+        // SVG transform="translate(0, 5) rotate(45)" applies rotate first, then translate
+        const matrix = { a: cos, b: sin, c: -sin, d: cos, e: 0, f: 5 };
+        Object.defineProperty(text, 'transform', {
+            value: { baseVal: { consolidate: () => ({ matrix }) } },
+            configurable: true
+        });
+
+        const corners: [number, number][] = [
+            [BBOX.x, BBOX.y],
+            [BBOX.x + BBOX.width, BBOX.y],
+            [BBOX.x, BBOX.y + BBOX.height],
+            [BBOX.x + BBOX.width, BBOX.y + BBOX.height]
+        ];
+        const ys = corners.map(([x, y]) => sin * x + cos * y + matrix.f);
+        const expectedHeight = Math.max(...ys) - Math.min(...ys);
+
+        expect(measureSvgTextLayoutExtent(text, 'height')).toBeCloseTo(expectedHeight, 5);
+        expect(measureSvgTextLayoutExtent(text, 'height')).toBeGreaterThan(BBOX.height);
+    });
+
+    it('T4: returns zero when getBBox throws', () => {
+        text.getBBox = vi.fn().mockImplementation(() => {
+            throw new Error('detached');
+        });
+        expect(measureSvgTextLayoutExtent(text, 'height')).toBe(0);
+    });
+});

--- a/packages/svelteplot/vitest.browser.config.js
+++ b/packages/svelteplot/vitest.browser.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import path from 'path';
 import * as url from 'url';
@@ -21,12 +22,12 @@ export default defineConfig({
         ]
     },
     test: {
-        include: [
-            'tests/**/*.{test,spec}.{js,ts,svelte.ts}',
-            'src/**/*.{test,spec}.{js,ts,svelte.ts}'
-        ],
-        exclude: ['tests/**/*.browser.test.svelte.ts'],
-        environment: 'jsdom',
-        setupFiles: ['./tests/setup.ts']
+        include: ['tests/**/*.browser.test.svelte.ts'],
+        setupFiles: ['vitest-browser-svelte'],
+        browser: {
+            enabled: true,
+            provider: playwright(),
+            instances: [{ browser: 'chromium' }]
+        }
     }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 1.3.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)))(svelte@5.51.5)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)))(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)))(rollup@2.80.0)(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4(@types/node@25.6.0)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)))
+        version: 5.3.1(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -191,7 +191,7 @@ importers:
         version: 5.51.5
       svelte-check:
         specifier: ^4.4.6
-        version: 4.4.6(picomatch@4.0.3)(svelte@5.51.5)(typescript@5.9.3)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.51.5)(typescript@5.9.3)
       svelte-eslint-parser:
         specifier: 1.6.0
         version: 1.6.0(svelte@5.51.5)
@@ -236,7 +236,7 @@ importers:
         version: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
       vitest-matchmedia-mock:
         specifier: ^2.0.3
         version: 2.0.3(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@27.4.0(postcss@8.5.6))(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)
@@ -312,7 +312,7 @@ importers:
         version: 6.2.4(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4(@types/node@25.6.0)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)))
+        version: 5.3.1(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -361,9 +361,15 @@ importers:
       '@types/topojson-client':
         specifier: ^3.1.5
         version: 3.1.5
+      '@vitest/browser-playwright':
+        specifier: 4.1.4
+        version: 4.1.4(playwright@1.61.1)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4)
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0(postcss@8.5.6)
+      playwright:
+        specifier: ^1.52.0
+        version: 1.61.1
       resize-observer-polyfill:
         specifier: ^1.5.1
         version: 1.5.1
@@ -381,7 +387,10 @@ importers:
         version: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+      vitest-browser-svelte:
+        specifier: ^2.1.1
+        version: 2.1.1(svelte@5.51.5)(vitest@4.1.4)
       vitest-matchmedia-mock:
         specifier: ^2.0.3
         version: 2.0.3(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@27.4.0(postcss@8.5.6))(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)
@@ -966,6 +975,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -2724,6 +2736,17 @@ packages:
       '@vite-pwa/assets-generator':
         optional: true
 
+  '@vitest/browser-playwright@4.1.4':
+    resolution: {integrity: sha512-q3PchVhZINX23Pv+RERgAtDlp6wzVkID/smOPnZ5YGWpeWUe3jMNYppeVh15j4il3G7JIJty1d1Kicpm0HSMig==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.4
+
+  '@vitest/browser@4.1.4':
+    resolution: {integrity: sha512-TrNaY/yVOwxtrxNsDUC/wQ56xSwplpytTeRAqF/197xV/ZddxxulBsxR6TrhVMyniJmp9in8d5u0AcDaNRY30w==}
+    peerDependencies:
+      vitest: 4.1.4
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -3777,6 +3800,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4794,6 +4822,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
@@ -5798,6 +5836,12 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vitest-browser-svelte@2.1.1:
+    resolution: {integrity: sha512-qbunYRSm+N92r9bfTkdDTpBZESLmp4QFz2SluV3n/x8U7ysosfeXYJZ4vXbJ0Y0LzoqqDnV5LHprmFgn4Eo+Ug==}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vitest: ^4.0.0
 
   vitest-matchmedia-mock@2.0.3:
     resolution: {integrity: sha512-Oa2fI+dfaqcs67D08PqBL0D+Ymm4MYGZn1WimUgfZGDxp9/eb8gl6xqPmhjyrV3p9KdhKj2tp6E1b4YWiSg1lw==}
@@ -6843,6 +6887,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@blazediff/core@1.9.1': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -7954,14 +8000,14 @@ snapshots:
     dependencies:
       svelte: 5.51.5
 
-  '@testing-library/svelte@5.3.1(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4(@types/node@25.6.0)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)))':
+  '@testing-library/svelte@5.3.1(svelte@5.51.5)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/svelte-core': 1.0.0(svelte@5.51.5)
       svelte: 5.51.5
     optionalDependencies:
       vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)
-      vitest: 4.1.4(@types/node@25.6.0)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
@@ -8462,6 +8508,36 @@ snapshots:
       - vite
       - workbox-build
       - workbox-window
+
+  '@vitest/browser-playwright@4.1.4(playwright@1.61.1)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4)':
+    dependencies:
+      '@vitest/browser': 4.1.4(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+      playwright: 1.61.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.4(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -9612,6 +9688,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -10902,6 +10981,14 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pngjs@7.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -11618,11 +11705,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.4.6(picomatch@4.0.3)(svelte@5.51.5)(typescript@5.9.3):
+  svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.51.5)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.51.5
@@ -12129,6 +12216,12 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)
 
+  vitest-browser-svelte@2.1.1(svelte@5.51.5)(vitest@4.1.4):
+    dependencies:
+      '@testing-library/svelte-core': 1.0.0(svelte@5.51.5)
+      svelte: 5.51.5
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
+
   vitest-matchmedia-mock@2.0.3(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@27.4.0(postcss@8.5.6))(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3):
     dependencies:
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(jiti@2.6.1)(jsdom@27.4.0(postcss@8.5.6))(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)
@@ -12196,7 +12289,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.4(@types/node@25.6.0)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(jsdom@27.4.0(postcss@8.5.6))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))
@@ -12220,6 +12313,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      '@vitest/browser-playwright': 4.1.4(playwright@1.61.1)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.16.5)(yaml@2.8.3))(vitest@4.1.4)
       jsdom: 27.4.0(postcss@8.5.6)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Fixes #179 by measuring axis tick labels in SVG user space instead of viewport pixels from `getBoundingClientRect()`.

When a parent applies `transform: scale()`, inflated margin measurements could feed a reactive loop between X/Y axis `$effect`s until Svelte throws `effect_update_depth_exceeded`. This PR replaces the viewport measurement with `measureSvgTextLayoutExtent()`, which:

- reads `getBBox()` on tick `<text>` elements (aggregating `<tspan>` children when needed)
- applies only the text element's local SVG transform for rotated X ticks
- returns `0` on detached/hidden elements instead of propagating bad geometry

## Test plan

- [x] Unit tests (`measureSvgTextLayoutExtent.test.ts`) — T1–T4: unscaled vs inflated gbcr, rotation, error handling
- [x] jsdom integration test — mocked 1.3× gbcr proves margins use bbox (~21) not inflated (~25)
- [x] Browser regression (Vitest + Playwright) — B1 no crash, B4 scale-invariance ±1px, B3 rotated ticks
- [x] Full jsdom suite: 840 tests pass
- [x] Browser suite: 4 tests pass

## CI

Adds `pnpm --filter svelteplot test:browser` to `.github/workflows/test.yml` with Playwright chromium install.

## Codex review

Independent diff review: **PASS** — no [P1] or [P2] findings.