### PR TITLE
fix(RuleY): widen data generic to accept raw values

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+        "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && pnpm --filter svelteplot check",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
         "dev": "vite dev",
         "docs": "npm run build && cd build && rsync --recursive . vis4.net:svelteplot/alpha0/",

--- a/packages/svelteplot/package.json
+++ b/packages/svelteplot/package.json
@@ -56,6 +56,7 @@
     ],
     "scripts": {
         "prepack": "npx svelte-package --input src && node scripts/fix-js-imports.js dist",
+        "check": "svelte-check --tsconfig tsconfig.check.json --threshold error",
         "test": "vitest run",
         "test:watch": "vitest"
     },

--- a/packages/svelteplot/src/marks/RuleX.svelte
+++ b/packages/svelteplot/src/marks/RuleX.svelte
@@ -1,7 +1,7 @@
 <!-- @component
     Renders vertical rule lines at specified x positions with customizable vertical range
 -->
-<script lang="ts" generics="Datum = DataRecord | RawValue">
+<script lang="ts" generics="Datum extends DataRecord | RawValue = DataRecord | RawValue">
     interface RuleXMarkProps extends Omit<BaseMarkProps<Datum>, 'fill' | 'fillOpacity'> {
         /** the input data array; each element becomes one vertical rule */
         data?: Datum[];

--- a/packages/svelteplot/src/marks/RuleY.svelte
+++ b/packages/svelteplot/src/marks/RuleY.svelte
@@ -1,7 +1,7 @@
 <!-- @component
     Renders horizontal rule lines at specified y positions with customizable horizontal range
 -->
-<script lang="ts" generics="Datum = DataRecord">
+<script lang="ts" generics="Datum extends DataRecord | RawValue = DataRecord | RawValue">
     interface RuleYMarkProps extends Omit<BaseMarkProps<Datum>, 'fill' | 'fillOpacity'> {
         /** the input data array; each element becomes one horizontal rule */
         data?: Datum[];
@@ -27,10 +27,10 @@
     import { resolveProp, resolveStyles } from '../helpers/resolve.js';
     import type {
         DataRecord,
-        DataRow,
         BaseMarkProps,
         ConstantAccessor,
-        ChannelAccessor
+        ChannelAccessor,
+        RawValue
     } from '../types/index.js';
     import { getPlotDefaults } from '../hooks/plotDefaults.js';
     import { IS_SORTED } from 'svelteplot/transforms/sort';
@@ -52,9 +52,7 @@
     });
 
     const plot = usePlot();
-    const args = $derived(
-        recordizeY({ data: data as DataRow[], ...options }, { withIndex: false })
-    );
+    const args = $derived(recordizeY({ data, ...options }, { withIndex: false }));
 </script>
 
 <Mark type="ruleY" channels={['y', 'x1', 'x2', 'stroke', 'opacity', 'strokeOpacity']} {...args}>

--- a/packages/svelteplot/tests/check-ambient.d.ts
+++ b/packages/svelteplot/tests/check-ambient.d.ts
@@ -1,0 +1,2 @@
+declare module 'interval-tree-1d';
+declare module 'd3-time';

--- a/packages/svelteplot/tests/ruleY.contract.test.ts
+++ b/packages/svelteplot/tests/ruleY.contract.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ruleYPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/marks/RuleY.svelte');
+
+describe('RuleY public type contract', () => {
+    const src = readFileSync(ruleYPath, 'utf8');
+
+    it('declares Datum extends DataRecord | RawValue', () => {
+        expect(src).toMatch(/generics="Datum extends DataRecord \| RawValue/);
+    });
+
+    it('passes data to recordizeY without a DataRow cast', () => {
+        expect(src).not.toMatch(/data as DataRow\[\]/);
+    });
+});

--- a/packages/svelteplot/tests/ruleY.contract.ts
+++ b/packages/svelteplot/tests/ruleY.contract.ts
@@ -1,0 +1,12 @@
+import type { ComponentProps } from 'svelte';
+import RuleY from '../src/marks/RuleY.svelte';
+
+type AssertRuleYProps<T extends ComponentProps<typeof RuleY>> = T;
+
+// Regression guards (green on main; stay green after fix)
+type _RawBaseline = AssertRuleYProps<{ data: [0, 1] }>;
+type _RecordRows = AssertRuleYProps<{ data: { y: number }[]; y: 'y' }>;
+type AssertTrue<T extends true> = T;
+type RuleYData = NonNullable<ComponentProps<typeof RuleY>['data']>;
+type _NumberArrayAssignable = [number[]] extends [RuleYData] ? true : false;
+type _ExpectNumberArray = AssertTrue<_NumberArrayAssignable>;

--- a/packages/svelteplot/tsconfig.check.json
+++ b/packages/svelteplot/tsconfig.check.json
@@ -1,0 +1,23 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "paths": {
+            "svelteplot": ["./src/index.ts"],
+            "svelteplot/*": ["./src/*"]
+        }
+    },
+    "include": [
+        "tests/ruleY.contract.ts",
+        "tests/check-ambient.d.ts",
+        "src/**/*.ts",
+        "src/**/*.svelte",
+        "src/**/*.js"
+    ],
+    "exclude": [
+        "tests/**/*.test.ts",
+        "tests/**/*.test.svelte.ts",
+        "tests/**/*.svelte",
+        "src/**/*.test.ts",
+        "src/**/*.spec.ts"
+    ]
+}


### PR DESCRIPTION
Closes #41

`RuleY` declared `Datum = DataRecord` but docs/runtime use `<RuleY data={[0]} />` and the component cast `data as DataRow[]` before `recordizeY`. The public generic didn't match what recordize marks accept.

- Widen to `Datum extends DataRecord | RawValue`, pass `data` directly (no cast)
- Add scoped `svelte-check` + source contract tests so this stays honest
- One-line `RuleX` generic alignment so `Box.svelte`'s dynamic `RuleMark` union still type-checks

PR #48 only changed prop types on marks; it didn't fix the generic boundary.